### PR TITLE
Go: do not panic in uaparser.New()

### DIFF
--- a/example/example.go
+++ b/example/example.go
@@ -3,12 +3,17 @@ package main
 import (
 	"../uaparser" // You could change this to a github repo as well
 	"fmt"
+	"os"
 )
 
 func main() {
 	testStr := "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_3; en-us; Silk/1.1.0-80) AppleWebKit/533.16 (KHTML, like Gecko) Version/5.0 Safari/533.16 Silk-Accelerated=true"
 	regexFile := "../../regexes.yaml"
-	parser := uaparser.New(regexFile)
+	parser, err := uaparser.New(regexFile)
+	if err != nil {
+		fmt.Println("Error:", err)
+		os.Exit(1)
+	}
 	client := parser.Parse(testStr)
 	fmt.Println(testStr)
 	fmt.Println("UserAgent: " + client.UserAgent.ToString())

--- a/uaparser/device_test.go
+++ b/uaparser/device_test.go
@@ -20,7 +20,7 @@ var dvcParser *Parser = nil
 
 func dvcInitParser(regexFile string) {
 	if dvcParser == nil {
-		dvcParser = New(regexFile)
+		dvcParser, _ = New(regexFile)
 	}
 }
 

--- a/uaparser/os_test.go
+++ b/uaparser/os_test.go
@@ -20,7 +20,7 @@ var osParser *Parser = nil
 
 func osInitParser(regexFile string) {
 	if osParser == nil {
-		osParser = New(regexFile)
+		osParser, _ = New(regexFile)
 	}
 }
 

--- a/uaparser/parser.go
+++ b/uaparser/parser.go
@@ -45,18 +45,18 @@ func ToStruct(interfaceArr []map[string]string, typeInterface interface{}, retur
 	*returnVal = structArr
 }
 
-func New(regexFile string) *Parser {
+func New(regexFile string) (*Parser, error) {
 	parser := new(Parser)
 
 	data, err := ioutil.ReadFile(regexFile)
 	if nil != err {
-		panic(err)
+		return nil, err
 	}
 
 	m := make(map[string][]map[string]string)
 	err = goyaml.Unmarshal(data, &m)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
 	var wg sync.WaitGroup
@@ -112,7 +112,7 @@ func New(regexFile string) *Parser {
 	parser.OsPatterns = osPatterns
 	parser.DevicePatterns = dvcPatterns
 
-	return parser
+	return parser, nil
 
 }
 

--- a/uaparser/user_agent_test.go
+++ b/uaparser/user_agent_test.go
@@ -20,7 +20,7 @@ var uaParser *Parser = nil
 
 func uaInitParser(regexFile string) {
 	if uaParser == nil {
-		uaParser = New(regexFile)
+		uaParser, _ = New(regexFile)
 	}
 }
 


### PR DESCRIPTION
Go packages should never expose panic in their external API except
for very extreme cases.

Fixes #1 
