### PR TITLE
example: allow specifying the regexes.yaml file as a commandline param

### DIFF
--- a/example/example.go
+++ b/example/example.go
@@ -9,6 +9,9 @@ import (
 func main() {
 	testStr := "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_3; en-us; Silk/1.1.0-80) AppleWebKit/533.16 (KHTML, like Gecko) Version/5.0 Safari/533.16 Silk-Accelerated=true"
 	regexFile := "../../regexes.yaml"
+	if len(os.Args) > 1 {
+		regexFile = os.Args[1]
+	}
 	parser, err := uaparser.New(regexFile)
 	if err != nil {
 		fmt.Println("Error:", err)


### PR DESCRIPTION
The hardcoded path assumes the old ua-parser repository structure