### PR TITLE
Fix os replacement logic

### DIFF
--- a/uaparser/os.go
+++ b/uaparser/os.go
@@ -31,22 +31,25 @@ func (osPattern *OsPattern) Match(line string, os *Os) {
 			os.Family = bytes[1]
 		}
 
-		if len(osPattern.OsV1Replacement) > 0 {
-			os.Major = osPattern.OsV1Replacement
-		} else if groupCount >= 2 {
-			os.Major = bytes[2]
-			if len(osPattern.OsV2Replacement) > 0 {
-				os.Minor = osPattern.OsV2Replacement
-			} else if groupCount >= 3 {
-				os.Minor = bytes[3]
-				if groupCount >= 4 {
-					os.Patch = bytes[4]
-					if groupCount >= 5 {
-						os.PatchMinor = bytes[5]
-					}
-				}
-			}
-		}
+        if len(osPattern.OsV1Replacement) > 0 {
+            os.Major = osPattern.OsV1Replacement
+        } else if groupCount >= 2 {
+            os.Major = bytes[2]
+        }
+
+        if len(osPattern.OsV2Replacement) > 0 {
+            os.Minor = osPattern.OsV2Replacement
+        } else if groupCount >= 3 {
+            os.Minor = bytes[3]
+        }
+
+        if groupCount >= 4 {
+            os.Patch = bytes[4]
+        }
+
+        if groupCount >= 5 {
+            os.PatchMinor = bytes[5]
+        }
 	}
 }
 


### PR DESCRIPTION
When testing against uap-core v0.4.0 (`master`'s `HEAD` doesn't work due to https://github.com/ua-parser/uap-core/issues/28), I saw this error when running `go test`:

```go
../../test_resources/test_device.yaml: PASS
../../test_resources/test_user_agent_parser_os.yaml: PASS
../../test_resources/additional_os_tests.yaml: FAIL
Expected: map[user_agent_string:Mozilla/5.0 (Linux; U; Android Donut; de-de; HTC Tattoo 1.52.161.1 Build/Donut) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1 family:Android major:1 minor:2 patch: patch_minor:]
Actual: &{Android 1   }
--- FAIL: TestAdditionalOs (0.00 seconds)
../../test_resources/test_user_agent_parser.yaml: PASS
../../test_resources/firefox_user_agent_strings.yaml: PASS
../../test_resources/pgts_browser_list.yaml: PASS
FAIL
exit status 1
FAIL	_/bitly/src/github/uap-go/uaparser	8.960s
```

In this case it seems that the minor version isn't being set because there's no second submatch. I skimmed uap-python and based on [this](https://github.com/ua-parser/uap-python/blob/master/ua_parser/user_agent_parser.py#L111) function I believe that this is incorrect - minor version should be populated according to the following logic:

```python
if self.v2_replacement:
        v2 = self.v2_replacement
elif match.lastindex and match.lastindex >= 3:
        v2 = match.group(3)
```

Also cleaned up logic in `os.Match` to more linear.