### PR TITLE
Add uap-core submodule + test refactoring

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "uap-core"]
+	path = uap-core
+	url = https://github.com/ua-parser/uap-core.git

--- a/uaparser/device.go
+++ b/uaparser/device.go
@@ -2,7 +2,6 @@ package uaparser
 
 import (
 	"regexp"
-	"strings"
 )
 
 type Device struct {
@@ -16,18 +15,14 @@ type DevicePattern struct {
 }
 
 func (dvcPattern *DevicePattern) Match(line string, dvc *Device) {
-	bytes := dvcPattern.Regexp.FindStringSubmatch(line)
-	if len(bytes) > 0 {
+	matches := dvcPattern.Regexp.FindStringSubmatch(line)
+	if len(matches) > 0 {
 		groupCount := dvcPattern.Regexp.NumSubexp()
 
 		if len(dvcPattern.DeviceReplacement) > 0 {
-			if strings.Contains(dvcPattern.DeviceReplacement, "$1") && groupCount >= 1 && len(bytes) >= 2 {
-				dvc.Family = strings.Replace(dvcPattern.DeviceReplacement, "$1", bytes[1], 1)
-			} else {
-				dvc.Family = dvcPattern.DeviceReplacement
-			}
+			dvc.Family = singleMatchReplacement(dvcPattern.DeviceReplacement, matches, 1)
 		} else if groupCount >= 1 {
-			dvc.Family = bytes[1]
+			dvc.Family = matches[1]
 		}
 	}
 }

--- a/uaparser/os.go
+++ b/uaparser/os.go
@@ -21,35 +21,35 @@ type OsPattern struct {
 }
 
 func (osPattern *OsPattern) Match(line string, os *Os) {
-	bytes := osPattern.Regexp.FindStringSubmatch(line)
-	if len(bytes) > 0 {
+	matches := osPattern.Regexp.FindStringSubmatch(line)
+	if len(matches) > 0 {
 		groupCount := osPattern.Regexp.NumSubexp()
 
 		if len(osPattern.OsReplacement) > 0 {
-			os.Family = osPattern.OsReplacement
+			os.Family = singleMatchReplacement(osPattern.OsReplacement, matches, 1)
 		} else if groupCount >= 1 {
-			os.Family = bytes[1]
+			os.Family = matches[1]
 		}
 
-        if len(osPattern.OsV1Replacement) > 0 {
-            os.Major = osPattern.OsV1Replacement
-        } else if groupCount >= 2 {
-            os.Major = bytes[2]
-        }
+		if len(osPattern.OsV1Replacement) > 0 {
+			os.Major = singleMatchReplacement(osPattern.OsV1Replacement, matches, 2)
+		} else if groupCount >= 2 {
+			os.Major = matches[2]
+		}
 
-        if len(osPattern.OsV2Replacement) > 0 {
-            os.Minor = osPattern.OsV2Replacement
-        } else if groupCount >= 3 {
-            os.Minor = bytes[3]
-        }
+		if len(osPattern.OsV2Replacement) > 0 {
+			os.Minor = singleMatchReplacement(osPattern.OsV2Replacement, matches, 3)
+		} else if groupCount >= 3 {
+			os.Minor = matches[3]
+		}
 
-        if groupCount >= 4 {
-            os.Patch = bytes[4]
-        }
+		if groupCount >= 4 {
+			os.Patch = matches[4]
+		}
 
-        if groupCount >= 5 {
-            os.PatchMinor = bytes[5]
-        }
+		if groupCount >= 5 {
+			os.PatchMinor = matches[5]
+		}
 	}
 }
 

--- a/uaparser/os_test.go
+++ b/uaparser/os_test.go
@@ -2,20 +2,10 @@ package uaparser
 
 import (
 	"fmt"
-	"gopkg.in/yaml.v2"
-	"io/ioutil"
 	"testing"
 )
 
-func osInitTesting(file string) []map[string]string {
-	fmt.Print(file + ": ")
-	testFile, _ := ioutil.ReadFile(file)
-	testMap := make(map[string][]map[string]string)
-	_ = yaml.Unmarshal(testFile, &testMap)
-	return testMap["test_cases"]
-}
-
-var osDefaultRegexFile string = "../../regexes.yaml"
+var osDefaultRegexFile string = uapCoreRoot + "/regexes.yaml"
 var osParser *Parser = nil
 
 func osInitParser(regexFile string) {
@@ -24,32 +14,19 @@ func osInitParser(regexFile string) {
 	}
 }
 
-func osTestHelper(file string) bool {
-	osInitParser(osDefaultRegexFile)
-	tests := osInitTesting(file)
-	for _, test := range tests {
-
-		// Other language ports of ua_parser skips js_ua in testing
-		if test["js_ua"] != "" {
-			continue
-		}
-
-		testingString := test["user_agent_string"]
-		os := osParser.ParseOs(testingString)
-
-		if os.Family != test["family"] || os.Major != test["major"] ||
-			os.Minor != test["minor"] || os.Patch != test["patch"] ||
-			os.PatchMinor != test["patch_minor"] {
-			fmt.Println("FAIL")
-			fmt.Printf("Expected: %v\nActual: %v\n", test, os)
-			return false
-		}
+func osTest(c *Client, test map[string]string) bool {
+	os := c.Os
+	if os.Family != test["family"] || os.Major != test["major"] ||
+		os.Minor != test["minor"] || os.Patch != test["patch"] ||
+		os.PatchMinor != test["patch_minor"] {
+		fmt.Printf("Expected: %v\nActual: %v\n", test, os)
+		return false
 	}
 	return true
 }
 
 func TestOs(t *testing.T) {
-	if !osTestHelper("../../test_resources/test_user_agent_parser_os.yaml") {
+	if !testHelper(uapCoreRoot+"/tests/test_os.yaml", osTest) {
 		t.Fail()
 	} else {
 		fmt.Println("PASS")
@@ -57,7 +34,7 @@ func TestOs(t *testing.T) {
 }
 
 func TestAdditionalOs(t *testing.T) {
-	if !osTestHelper("../../test_resources/additional_os_tests.yaml") {
+	if !testHelper(uapCoreRoot+"/test_resources/additional_os_tests.yaml", osTest) {
 		t.Fail()
 	} else {
 		fmt.Println("PASS")

--- a/uaparser/parser.go
+++ b/uaparser/parser.go
@@ -6,6 +6,8 @@ import (
 	"io/ioutil"
 	"reflect"
 	"regexp"
+	"strconv"
+	"strings"
 	"sync"
 )
 
@@ -170,4 +172,12 @@ func (parser *Parser) Parse(line string) *Client {
 	cli.Os = parser.ParseOs(line)
 	cli.Device = parser.ParseDevice(line)
 	return cli
+}
+
+func singleMatchReplacement(replacement string, matches []string, idx int) string {
+	token := "$" + strconv.Itoa(idx)
+	if strings.Contains(replacement, token) {
+		return strings.Replace(replacement, token, matches[idx], -1)
+	}
+	return replacement
 }

--- a/uaparser/user_agent.go
+++ b/uaparser/user_agent.go
@@ -2,7 +2,6 @@ package uaparser
 
 import (
 	"regexp"
-	"strings"
 )
 
 type UserAgent struct {
@@ -21,32 +20,28 @@ type UserAgentPattern struct {
 }
 
 func (uaPattern *UserAgentPattern) Match(line string, ua *UserAgent) {
-	bytes := uaPattern.Regexp.FindStringSubmatch(line)
-	if len(bytes) > 0 {
+	matches := uaPattern.Regexp.FindStringSubmatch(line)
+	if len(matches) > 0 {
 		groupCount := uaPattern.Regexp.NumSubexp()
 
 		if len(uaPattern.FamilyReplacement) > 0 {
-			if strings.Contains(uaPattern.FamilyReplacement, "$1") && groupCount >= 1 && len(bytes) >= 2 {
-				ua.Family = strings.Replace(uaPattern.FamilyReplacement, "$1", bytes[1], 1)
-			} else {
-				ua.Family = uaPattern.FamilyReplacement
-			}
+			ua.Family = singleMatchReplacement(uaPattern.FamilyReplacement, matches, 1)
 		} else if groupCount >= 1 {
-			ua.Family = bytes[1]
+			ua.Family = matches[1]
 		}
 
 		if len(uaPattern.V1Replacement) > 0 {
-			ua.Major = uaPattern.V1Replacement
+			ua.Major = singleMatchReplacement(uaPattern.V1Replacement, matches, 2)
 		} else if groupCount >= 2 {
-			ua.Major = bytes[2]
+			ua.Major = matches[2]
 		}
 
 		if len(uaPattern.V2Replacement) > 0 {
-			ua.Minor = uaPattern.V2Replacement
+			ua.Minor = singleMatchReplacement(uaPattern.V2Replacement, matches, 3)
 		} else if groupCount >= 3 {
-			ua.Minor = bytes[3]
+			ua.Minor = matches[3]
 			if groupCount >= 4 {
-				ua.Patch = bytes[4]
+				ua.Patch = matches[4]
 			}
 		}
 	}

--- a/uaparser/user_agent_test.go
+++ b/uaparser/user_agent_test.go
@@ -2,20 +2,10 @@ package uaparser
 
 import (
 	"fmt"
-	"gopkg.in/yaml.v2"
-	"io/ioutil"
 	"testing"
 )
 
-func uaInitTesting(file string) []map[string]string {
-	fmt.Print(file + ": ")
-	testFile, _ := ioutil.ReadFile(file)
-	testMap := make(map[string][]map[string]string)
-	_ = yaml.Unmarshal(testFile, &testMap)
-	return testMap["test_cases"]
-}
-
-var uaDefaultRegexFile string = "../../regexes.yaml"
+var uaDefaultRegexFile string = uapCoreRoot + "/regexes.yaml"
 var uaParser *Parser = nil
 
 func uaInitParser(regexFile string) {
@@ -24,31 +14,18 @@ func uaInitParser(regexFile string) {
 	}
 }
 
-func uaHelperTest(file string) bool {
-	uaInitParser(uaDefaultRegexFile)
-	tests := uaInitTesting(file)
-	for _, test := range tests {
-
-		// Other language ports of ua_parser skips js_ua in testing
-		if test["js_ua"] != "" {
-			continue
-		}
-
-		testingString := test["user_agent_string"]
-		ua := uaParser.ParseUserAgent(testingString)
-
-		if ua.Family != test["family"] || ua.Major != test["major"] ||
-			ua.Minor != test["minor"] || ua.Patch != test["patch"] {
-			fmt.Println("FAIL")
-			fmt.Printf("Expected: %v\nActual: %v\n", test, ua)
-			return false
-		}
+func uaTest(c *Client, test map[string]string) bool {
+	ua := c.UserAgent
+	if ua.Family != test["family"] || ua.Major != test["major"] ||
+		ua.Minor != test["minor"] || ua.Patch != test["patch"] {
+		fmt.Printf("Expected: %v\nActual: %v\n", test, ua)
+		return false
 	}
 	return true
 }
 
 func TestUserAgent(t *testing.T) {
-	if !uaHelperTest("../../test_resources/test_user_agent_parser.yaml") {
+	if !testHelper(uapCoreRoot+"/tests/test_ua.yaml", uaTest) {
 		t.Fail()
 	} else {
 		fmt.Println("PASS")
@@ -56,7 +33,7 @@ func TestUserAgent(t *testing.T) {
 }
 
 func TestFirefoxUserAgents(t *testing.T) {
-	if !uaHelperTest("../../test_resources/firefox_user_agent_strings.yaml") {
+	if !testHelper(uapCoreRoot+"/test_resources/firefox_user_agent_strings.yaml", uaTest) {
 		t.Fail()
 	} else {
 		fmt.Println("PASS")
@@ -64,7 +41,7 @@ func TestFirefoxUserAgents(t *testing.T) {
 }
 
 func TestPgtsBrowsersList(t *testing.T) {
-	if !uaHelperTest("../../test_resources/pgts_browser_list.yaml") {
+	if !testHelper(uapCoreRoot+"/test_resources/pgts_browser_list.yaml", uaTest) {
 		t.Fail()
 	} else {
 		fmt.Println("PASS")


### PR DESCRIPTION
* Add uap-core as submodule (pinned to v0.4.0 since this parser isn't using PCRE: https://github.com/ua-parser/uap-core/issues/28)
* Refactor some test functions + fail tests when testfile doesn't exist
* Fix OS parsing logic for failed test
* `go fmt`

I thought that tests were passing after https://github.com/ua-parser/uap-go/pull/7 (when testing against uap-core v0.4.0), but this isn't the case: when test files are nonexistent the test suite silently passes the associated test. After fixing this issue I saw that the following test fails:

```go
Expected: map[user_agent_string:Mozilla/5.0 (Windows U; Win NT 5.0; en-US; rv:1.8.0.2) Gecko/20060308 Firefox/1.5.0.2 family:Windows NT major: minor: patch: patch_minor:]
Actual: &{Windows $1 }
```

The OS parser wasn't populating the replacement string with submatch string. After this fix, all tests against the submodule pass.