### PR TITLE
Make the tests pass

### DIFF
--- a/uap-core/.travis.yml
+++ b/uap-core/.travis.yml
@@ -1,6 +1,9 @@
+sudo: false
 language: node_js
 node_js:
-  - 0.8
+  - 0.12
+  - 4
+  - node
 
 script:
   - "npm test"

--- a/uap-core/package.json
+++ b/uap-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "uap-core",
   "description": "The regex file necessary to build language ports of Browserscope's user agent parser.",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "maintainers": [
     {
       "name": "Tobie Langel",

--- a/uap-core/regexes.yaml
+++ b/uap-core/regexes.yaml
@@ -30,7 +30,7 @@ user_agent_parsers:
   - regex: '(Google-HTTP-Java-Client|Apache-HttpClient|http%20client|Python-urllib|HttpMonitor|TLSProber|WinHTTP|JNLP)(?:[ /](\d+)(?:\.(\d+)(?:\.(\d+))?)?)?'
 
   # Bots
-  - regex: '(1470\.net crawler|50\.nu|8bo Crawler Bot|Aboundex|Accoona-[A-z]+-Agent|AdsBot-Google(?:-[a-z]+)?|altavista|AppEngine-Google|archive.*?\.org_bot|archiver|Ask Jeeves|[Bb]ai[Dd]u[Ss]pider(?:-[A-Za-z]+)*|bingbot|BingPreview|blitzbot|BlogBridge|BoardReader(?: [A-Za-z]+)*|boitho.com-dc|BotSeer|\b\w*favicon\w*\b|\bYeti(?:-[a-z]+)?|Catchpoint bot|[Cc]harlotte|Checklinks|clumboot|Comodo HTTP\(S\) Crawler|Comodo-Webinspector-Crawler|ConveraCrawler|CRAWL-E|CrawlConvera|Daumoa(?:-feedfetcher)?|Feed Seeker Bot|findlinks|Flamingo_SearchEngine|FollowSite Bot|furlbot|Genieo|gigabot|GomezAgent|gonzo1|(?:[a-zA-Z]+-)?Googlebot(?:-[a-zA-Z]+)?|Google SketchUp|grub-client|gsa-crawler|heritrix|HiddenMarket|holmes|HooWWWer|htdig|ia_archiver|ICC-Crawler|Icarus6j|ichiro(?:/mobile)?|IconSurf|IlTrovatore(?:-Setaccio)?|InfuzApp|Innovazion Crawler|InternetArchive|IP2[a-z]+Bot|jbot\b|KaloogaBot|Kraken|Kurzor|larbin|LEIA|LesnikBot|Linguee Bot|LinkAider|LinkedInBot|Lite Bot|Llaut|lycos|Mail\.RU_Bot|masidani_bot|Mediapartners-Google|Microsoft .*? Bot|mogimogi|mozDex|MJ12bot|msnbot(?:-media *)?|msrbot|netresearch|Netvibes|NewsGator[^/]*|^NING|Nutch[^/]*|Nymesis|ObjectsSearch|Orbiter|OOZBOT|PagePeeker|PagesInventory|PaxleFramework|Peeplo Screenshot Bot|PlantyNet_WebRobot|Pompos|Read%20Later|Reaper|RedCarpet|Retreiver|Riddler|Riddler|Rival IQ|scooter|Scrapy|Scrubby|searchsight|seekbot|semanticdiscovery|Simpy|SimplePie|SEOstats|SimpleRSS|Slurp|snappy|Speedy Spider|Squrl Java|TheUsefulbot|ThumbShotsBot|Thumbshots\.ru|TwitterBot|URL2PNG|Vagabondo|VoilaBot|^vortex|Votay bot|^voyager|WASALive.Bot|Web-sniffer|WebThumb|WeSEE:[A-z]+|WhatWeb|WIRE|WordPress|Wotbox|www\.almaden\.ibm\.com|Xenu(?:.s)? Link Sleuth|Xerka [A-z]+Bot|yacy(?:bot)?|Yahoo[a-z]*Seeker|Yahoo! Slurp|Yandex\w+|YodaoBot(?:-[A-z]+)?|YottaaMonitor|Yowedo|^Zao|^Zao-Crawler|ZeBot_www\.ze\.bz|ZooShot|ZyBorg)(?:[ /]v?(\d+)(?:\.(\d+)(?:\.(\d+))?)?)?'
+  - regex: '(1470\.net crawler|50\.nu|8bo Crawler Bot|Aboundex|Accoona-[A-z]+-Agent|AdsBot-Google(?:-[a-z]+)?|altavista|AppEngine-Google|archive.*?\.org_bot|archiver|Ask Jeeves|[Bb]ai[Dd]u[Ss]pider(?:-[A-Za-z]+)*|bingbot|BingPreview|blitzbot|BlogBridge|BoardReader(?: [A-Za-z]+)*|boitho.com-dc|BotSeer|\b\w*favicon\w*\b|\bYeti(?:-[a-z]+)?|Catchpoint bot|[Cc]harlotte|Checklinks|clumboot|Comodo HTTP\(S\) Crawler|Comodo-Webinspector-Crawler|ConveraCrawler|CRAWL-E|CrawlConvera|Daumoa(?:-feedfetcher)?|Feed Seeker Bot|findlinks|Flamingo_SearchEngine|FollowSite Bot|furlbot|Genieo|gigabot|GomezAgent|gonzo1|(?:[a-zA-Z]+-)?Googlebot(?:-[a-zA-Z]+)?|Google SketchUp|grub-client|gsa-crawler|heritrix|HiddenMarket|holmes|HooWWWer|htdig|ia_archiver|ICC-Crawler|Icarus6j|ichiro(?:/mobile)?|IconSurf|IlTrovatore(?:-Setaccio)?|InfuzApp|Innovazion Crawler|InternetArchive|IP2[a-z]+Bot|jbot\b|KaloogaBot|Kraken|Kurzor|larbin|LEIA|LesnikBot|Linguee Bot|LinkAider|LinkedInBot|Lite Bot|Llaut|lycos|Mail\.RU_Bot|masidani_bot|Mediapartners-Google|Microsoft .*? Bot|mogimogi|mozDex|MJ12bot|msnbot(?:-media *)?|msrbot|netresearch|Netvibes|NewsGator[^/]*|^NING|Nutch[^/]*|Nymesis|ObjectsSearch|Orbiter|OOZBOT|PagePeeker|PagesInventory|PaxleFramework|Peeplo Screenshot Bot|PlantyNet_WebRobot|Pompos|Read%20Later|Reaper|RedCarpet|Retreiver|Riddler|Riddler|Rival IQ|scooter|Scrapy|Scrubby|searchsight|seekbot|semanticdiscovery|Simpy|SimplePie|SEOstats|SimpleRSS|SiteCon|Slurp|snappy|Speedy Spider|Squrl Java|TheUsefulbot|ThumbShotsBot|Thumbshots\.ru|TwitterBot|URL2PNG|Vagabondo|VoilaBot|^vortex|Votay bot|^voyager|WASALive.Bot|Web-sniffer|WebThumb|WeSEE:[A-z]+|WhatWeb|WIRE|WordPress|Wotbox|www\.almaden\.ibm\.com|Xenu(?:.s)? Link Sleuth|Xerka [A-z]+Bot|yacy(?:bot)?|Yahoo[a-z]*Seeker|Yahoo! Slurp|Yandex\w+|YodaoBot(?:-[A-z]+)?|YottaaMonitor|Yowedo|^Zao|^Zao-Crawler|ZeBot_www\.ze\.bz|ZooShot|ZyBorg)(?:[ /]v?(\d+)(?:\.(\d+)(?:\.(\d+))?)?)?'
 
   # Bots General matcher 'name/0.0'
   - regex: '(?:\/[A-Za-z0-9\.]+)? *([A-Za-z0-9 \-_\!\[\]:]*(?:[Aa]rchiver|[Ii]ndexer|[Ss]craper|[Bb]ot|[Ss]pider|[Cc]rawl[a-z]*))/(\d+)(?:\.(\d+)(?:\.(\d+))?)?'
@@ -73,6 +73,8 @@ user_agent_parsers:
   - regex: '(Firefox).*Tablet browser (\d+)\.(\d+)\.(\d+)'
     family_replacement: 'MicroB'
   - regex: '(MozillaDeveloperPreview)/(\d+)\.(\d+)([ab]\d+[a-z]*)?'
+  - regex: '(FxiOS)/(\d+)\.(\d+)(\.(\d+))?(\.(\d+))?'
+    family_replacement: 'Firefox iOS'
 
   # e.g.: Flock/2.0b2
   - regex: '(Flock)/(\d+)\.(\d+)(b\d+?)'
@@ -255,7 +257,7 @@ user_agent_parsers:
   #### MAIN CASES - this catches > 50% of all browsers ####
 
   # Browser/major_version.minor_version.beta_version
-  - regex: '(AdobeAIR|FireWeb|Jasmine|ANTGalio|Midori|Fresco|Lobo|PaleMoon|Maxthon|Lynx|OmniWeb|Dillo|Camino|Demeter|Fluid|Fennec|Epiphany|Shiira|Sunrise|Flock|Netscape|Lunascape|WebPilot|NetFront|Netfront|Konqueror|SeaMonkey|Kazehakase|Vienna|Iceape|Iceweasel|IceWeasel|Iron|K-Meleon|Sleipnir|Galeon|GranParadiso|Opera Mini|iCab|NetNewsWire|ThunderBrowse|Iris|UP\.Browser|Bunjalloo|Google Earth|Raven for Mac|Openwave)/(\d+)\.(\d+)\.(\d+)'
+  - regex: '(AdobeAIR|FireWeb|Jasmine|ANTGalio|Midori|Fresco|Lobo|PaleMoon|Maxthon|Lynx|OmniWeb|Dillo|Camino|Demeter|Fluid|Fennec|Epiphany|Shiira|Sunrise|Spotify|Flock|Netscape|Lunascape|WebPilot|NetFront|Netfront|Konqueror|SeaMonkey|Kazehakase|Vienna|Iceape|Iceweasel|IceWeasel|Iron|K-Meleon|Sleipnir|Galeon|GranParadiso|Opera Mini|iCab|NetNewsWire|ThunderBrowse|Iris|UP\.Browser|Bunjalloo|Google Earth|Raven for Mac|Openwave)/(\d+)\.(\d+)\.(\d+)'
 
   # Outlook 2007
   - regex: 'MSOffice 12'
@@ -787,6 +789,9 @@ os_parsers:
     os_replacement: 'Mac OS X'
     os_v1_replacement: '10'
     os_v2_replacement: '10'
+  - regex: '(CF)(Network)/758\.(\d)'
+    os_replacement: 'iOS'
+    os_v1_replacement: '9'
 
   ##########
   # CFNetwork iOS Apps
@@ -810,6 +815,10 @@ os_parsers:
   - regex: 'CFNetwork/7.* Darwin/(14)\.\d+'
     os_replacement: 'iOS'
     os_v1_replacement: '8'
+    os_v2_replacement: '0'
+  - regex: 'CFNetwork/7.* Darwin/(15)\.\d+'
+    os_replacement: 'iOS'
+    os_v1_replacement: '9'
     os_v2_replacement: '0'
   # iOS Apps
   - regex: '\b(iOS[ /]|iPhone(?:/| v|[ _]OS[/,]|; | OS : |\d,\d/|\d,\d; )|iPad/)(\d{1,2})[_\.](\d{1,2})(?:[_\.](\d+))?'
@@ -873,8 +882,46 @@ os_parsers:
   ##########
   # Firefox OS
   ##########
+  - regex: '\((?:Mobile|Tablet);.+Gecko/18.0 Firefox/\d+\.\d+'
+    os_replacement: 'Firefox OS'
+    os_v1_replacement: '1'
+    os_v2_replacement: '0'
+    os_v3_replacement: '1'
+
+  - regex: '\((?:Mobile|Tablet);.+Gecko/18.1 Firefox/\d+\.\d+'
+    os_replacement: 'Firefox OS'
+    os_v1_replacement: '1'
+    os_v2_replacement: '1'
+
+  - regex: '\((?:Mobile|Tablet);.+Gecko/26.0 Firefox/\d+\.\d+'
+    os_replacement: 'Firefox OS'
+    os_v1_replacement: '1'
+    os_v2_replacement: '2'
+
+  - regex: '\((?:Mobile|Tablet);.+Gecko/28.0 Firefox/\d+\.\d+'
+    os_replacement: 'Firefox OS'
+    os_v1_replacement: '1'
+    os_v2_replacement: '3'
+
+  - regex: '\((?:Mobile|Tablet);.+Gecko/30.0 Firefox/\d+\.\d+'
+    os_replacement: 'Firefox OS'
+    os_v1_replacement: '1'
+    os_v2_replacement: '4'
+
+  - regex: '\((?:Mobile|Tablet);.+Gecko/32.0 Firefox/\d+\.\d+'
+    os_replacement: 'Firefox OS'
+    os_v1_replacement: '2'
+    os_v2_replacement: '0'
+
+  - regex: '\((?:Mobile|Tablet);.+Gecko/34.0 Firefox/\d+\.\d+'
+    os_replacement: 'Firefox OS'
+    os_v1_replacement: '2'
+    os_v2_replacement: '1'
+
+  # Firefox OS Generic
   - regex: '\((?:Mobile|Tablet);.+Firefox/\d+\.\d+'
     os_replacement: 'Firefox OS'
+
 
   ##########
   # BREW
@@ -2002,9 +2049,9 @@ device_parsers:
   #########
 
   - regex: '; *HTC[ _]([^;]+); Windows Phone'
-    device_replacement: 'HTC $1 $2'
+    device_replacement: 'HTC $1'
     brand_replacement: 'HTC'
-    model_replacement: '$1 $2'
+    model_replacement: '$1'
 
   # Android HTC with Version Number matcher
   # ; HTC_0P3Z11/1.12.161.3 Build
@@ -2036,9 +2083,9 @@ device_parsers:
     brand_replacement: 'HTC'
     model_replacement: '$1 $2'
   - regex: '; *(?:(?:HTC|htc)(?:_blocked)*[ _/])+([^ _/]+)(?:[ _/]([^ _/]+)(?:[ _/]([^ _/;\)]+))?)?(?: *Build|[;\)]| - )'
-    device_replacement: 'HTC $1 $2 $3 $4'
+    device_replacement: 'HTC $1 $2 $3'
     brand_replacement: 'HTC'
-    model_replacement: '$1 $2 $3 $4'
+    model_replacement: '$1 $2 $3'
   - regex: '; *(?:(?:HTC|htc)(?:_blocked)*[ _/])+([^ _/]+)(?:[ _/]([^ _/]+)(?:[ _/]([^ _/]+)(?:[ _/]([^ /;]+))?)?)?(?: *Build|[;\)]| - )'
     device_replacement: 'HTC $1 $2 $3 $4'
     brand_replacement: 'HTC'
@@ -2063,9 +2110,9 @@ device_parsers:
     model_replacement: '$1'
   - regex: '; *(ADR6200|ADR6400L|ADR6425LVW|Amaze|DesireS?|EndeavorU|Eris|EVO|Evo\d[A-Z]+|HD2|IncredibleS?|Inspire[A-Z0-9]*|Inspire[A-Z0-9]*|Sensation[A-Z0-9]*|Wildfire)[ _-](.+?)(?:[/;\)]|Build|MIUI|1\.0)'
     regex_flag: 'i'
-    device_replacement: 'HTC $1 $2 $3 $4'
+    device_replacement: 'HTC $1 $2'
     brand_replacement: 'HTC'
-    model_replacement: '$1 $2 $3 $4'
+    model_replacement: '$1 $2'
 
   #########
   # Hyundai

--- a/uap-core/tests/test_os.yaml
+++ b/uap-core/tests/test_os.yaml
@@ -2123,3 +2123,67 @@ test_cases:
     minor:
     patch:
     patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Mobile; rv:26.0) Gecko/18.0 Firefox/26.0'
+    family: 'Firefox OS'
+    major: '1'
+    minor: '0'
+    patch: '1'
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Mobile; rv:26.0) Gecko/18.1 Firefox/26.0'
+    family: 'Firefox OS'
+    major: '1'
+    minor: '1'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Mobile; rv:26.0) Gecko/26.0 Firefox/26.0'
+    family: 'Firefox OS'
+    major: '1'
+    minor: '2'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Mobile; rv:26.0) Gecko/28.0 Firefox/26.0'
+    family: 'Firefox OS'
+    major: '1'
+    minor: '3'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Mobile; rv:26.0) Gecko/30.0 Firefox/26.0'
+    family: 'Firefox OS'
+    major: '1'
+    minor: '4'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Mobile; rv:26.0) Gecko/32.0 Firefox/26.0'
+    family: 'Firefox OS'
+    major: '2'
+    minor: '0'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Mobile; rv:26.0) Gecko/34.0 Firefox/26.0'
+    family: 'Firefox OS'
+    major: '2'
+    minor: '1'
+    patch:
+    patch_minor:
+
+  # Test generic Firefox OS matching
+  - user_agent_string: 'Mozilla/5.0 (Mobile; rv:26.0) Gecko/11.0 Firefox/26.0'
+    family: 'Firefox OS'
+    major:
+    minor:
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'TestApp/1.0 CFNetwork/758.0.2 Darwin/15.0.0'
+    family: 'iOS'
+    major: '9'
+    minor: '0'
+    patch:
+    patch_minor:

--- a/uap-core/tests/test_ua.yaml
+++ b/uap-core/tests/test_ua.yaml
@@ -6111,3 +6111,51 @@ test_cases:
     minor:
     patch:
 
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; en-gb) AppleWebKit/418.9.1 (KHTML, like Gecko) SiteCon/8.10.9'
+    family: 'SiteCon'
+    major: '8'
+    minor: '10'
+    patch: '9'
+
+  - user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/1.0 Mobile/12F69 Safari/600.1.4'
+    family: 'Firefox iOS'
+    major: '1'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Mozilla/5.0 (iPad; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/1.0 Mobile/12F69 Safari/600.1.4'
+    family: 'Firefox iOS'
+    major: '1'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_4) AppleWebKit/537.36 (KHTML, like Gecko) Spotify/1.0.9.133 Safari/537.36'
+    family: 'Spotify'
+    major: '1'
+    minor: '0'
+    patch: '9'
+
+  - user_agent_string: 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Spotify/1.0.9.133 Safari/537.36'
+    family: 'Spotify'
+    major: '1'
+    minor: '0'
+    patch: '9'
+
+  - user_agent_string: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_5) AppleWebKit/537.36 (KHTML, like Gecko) Spotify/1.0.4.90 Safari/537.36'
+    family: 'Spotify'
+    major: '1'
+    minor: '0'
+    patch: '4'
+
+   - user_agent_string: 'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Spotify/1.0.3.101 Safari/537.36'
+    family: 'Spotify'
+    major: '1'
+    minor: '0'
+    patch: '3'
+
+   - user_agent_string: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/537.36 (KHTML, like Gecko) Spotify/1.0.8.59 Safari/537.36'
+    family: 'Spotify'
+    major: '1'
+    minor: '0'
+    patch: '8'
+

--- a/uaparser/device.go
+++ b/uaparser/device.go
@@ -2,6 +2,7 @@ package uaparser
 
 import (
 	"regexp"
+	"strings"
 )
 
 type Device struct {
@@ -19,15 +20,17 @@ type DevicePattern struct {
 
 func (dvcPattern *DevicePattern) Match(line string, dvc *Device) {
 	matches := dvcPattern.Regexp.FindStringSubmatch(line)
-	if len(matches) > 0 {
-		groupCount := dvcPattern.Regexp.NumSubexp()
-
-		if len(dvcPattern.DeviceReplacement) > 0 {
-			dvc.Family = singleMatchReplacement(dvcPattern.DeviceReplacement, matches, 1)
-		} else if groupCount >= 1 {
-			dvc.Family = matches[1]
-		}
+	if len(matches) == 0 {
+		return
 	}
+	groupCount := dvcPattern.Regexp.NumSubexp()
+
+	if len(dvcPattern.DeviceReplacement) > 0 {
+		dvc.Family = allMatchesReplacement(dvcPattern.DeviceReplacement, matches)
+	} else if groupCount >= 1 {
+		dvc.Family = matches[1]
+	}
+	dvc.Family = strings.TrimSpace(dvc.Family)
 }
 
 func (dvc *Device) ToString() string {

--- a/uaparser/os.go
+++ b/uaparser/os.go
@@ -18,6 +18,7 @@ type OsPattern struct {
 	OsReplacement   string
 	OsV1Replacement string
 	OsV2Replacement string
+	OsV3Replacement string
 }
 
 func (osPattern *OsPattern) Match(line string, os *Os) {
@@ -43,7 +44,9 @@ func (osPattern *OsPattern) Match(line string, os *Os) {
 			os.Minor = matches[3]
 		}
 
-		if groupCount >= 4 {
+		if len(osPattern.OsV3Replacement) > 0 {
+			os.Patch = singleMatchReplacement(osPattern.OsV3Replacement, matches, 4)
+		} else if groupCount >= 4 {
 			os.Patch = matches[4]
 		}
 

--- a/uaparser/parser.go
+++ b/uaparser/parser.go
@@ -2,6 +2,7 @@ package uaparser
 
 import (
 	"bytes"
+	"fmt"
 	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"reflect"
@@ -114,7 +115,12 @@ func (parser *Parser) newFromBytes(data []byte) (*Parser, error) {
 		dvcPatterns = make([]DevicePattern, len(dvcInterfaces))
 		for i, inter := range dvcInterfaces {
 			dvcPatterns[i] = inter.(DevicePattern)
-			dvcPatterns[i].Regexp = regexp.MustCompile(dvcPatterns[i].Regex)
+			flags := ""
+			if strings.Contains(dvcPatterns[i].RegexFlag, "i") {
+				flags = "(?i)"
+			}
+			regexString := fmt.Sprintf("%s%s", flags, dvcPatterns[i].Regex)
+			dvcPatterns[i].Regexp = regexp.MustCompile(regexString)
 		}
 		wg.Done()
 	}()

--- a/uaparser/parser_test.go
+++ b/uaparser/parser_test.go
@@ -1,0 +1,60 @@
+package uaparser
+
+import (
+	"testing"
+)
+
+func testAllMatchesReplacement(t *testing.T, expected, pattern string, values []string) {
+	actual := allMatchesReplacement(pattern, values)
+	if actual != expected {
+		t.Fatalf("Expected '%s', but got '%s' while replacing tokens in '%s' with %v", expected, actual, pattern, values)
+	}
+}
+
+func TestAllMatchesReplacementEmptyPattern(t *testing.T) {
+	testAllMatchesReplacement(t, "", "", []string{"whole match"})
+	testAllMatchesReplacement(t, "", "", []string{"whole match", "a"})
+}
+
+func TestAllMatchesReplacementNoTokensInPattern(t *testing.T) {
+	testAllMatchesReplacement(t, "foo", "foo", []string{"whole match"})
+	testAllMatchesReplacement(t, "foo", "foo", []string{"whole match", "a"})
+	testAllMatchesReplacement(t, "100$", "100$", []string{"whole match", "a"})
+	testAllMatchesReplacement(t, "$not-a-token", "$not-a-token", []string{"whole match", "a"})
+	testAllMatchesReplacement(t, "$ ", "$ ", []string{"whole match", "a"})
+	testAllMatchesReplacement(t, "$$$", "$$$", []string{"whole match", "a"})
+}
+
+func TestAllMatchesReplacementNoValueForToken(t *testing.T) {
+	testAllMatchesReplacement(t, "$1 $3 $2", "$1 $3 $2", []string{"whole match"})
+	testAllMatchesReplacement(t, "one $3 $2", "$1 $3 $2", []string{"whole match", "one"})
+	testAllMatchesReplacement(t, "one $3 two", "$1 $3 $2", []string{"whole match", "one", "two"})
+}
+
+func TestAllMatchesReplacementMultidigitToken(t *testing.T) {
+	testAllMatchesReplacement(t, "$10 > $1", "$10 > $1", []string{"whole match"})
+	testAllMatchesReplacement(t, "$10 > one", "$10 > $1", []string{"whole match", "one"})
+	testAllMatchesReplacement(t, "$10 > one", "$10 > $1", []string{"whole match", "one"})
+	testAllMatchesReplacement(t, "ten > one", "$10 > $1",
+		[]string{"whole match", "one", "2", "3", "4", "5", "6", "7", "8", "9", "ten"})
+}
+
+func TestAllMatchesReplacementTokenInsideToken(t *testing.T) {
+	testAllMatchesReplacement(t, "one $1 $3 three", "$1 $2 $3", []string{"whole match", "one", "$1 $3", "three"})
+}
+
+func TestAllMatchesReplacementDuplicateToken(t *testing.T) {
+	testAllMatchesReplacement(t, "a, a and a", "$1, $1 and $1", []string{"whole match", "a"})
+}
+
+func TestAllMatchesReplacementSkipsNotTokens(t *testing.T) {
+	testAllMatchesReplacement(t, "$100", "$$1", []string{"whole match", "100"})
+	testAllMatchesReplacement(t, "100$", "$1$", []string{"whole match", "100"})
+	testAllMatchesReplacement(t, "$0", "$0", []string{"whole match", "100"})
+	testAllMatchesReplacement(t, "$+1", "$+1", []string{"whole match", "100"})
+	testAllMatchesReplacement(t, "$-1", "$-1", []string{"whole match", "100"})
+}
+
+func TestAllMatchesReplacementTooBigIndex(t *testing.T) {
+	testAllMatchesReplacement(t, "$99999999999999999999", "$99999999999999999999", []string{"whole match"})
+}


### PR DESCRIPTION
In order to make the tests pass I've added a few things:
 - os_v3_replacement was added recently, so I added handling of it
 - regex_flag now is not ignored
 - device family matching now replaces all submatches($1, $2 and so on) in the replacement string, not just $1

Version of uap-core contains some yaml which is not quite valid, so I fixed the file in uap-core repo: https://github.com/ua-parser/uap-core/pull/91