### PR TITLE
Update to latest uap-core; add update instructions to contributing.md

### DIFF
--- a/uap-core/CONTRIBUTING.md
+++ b/uap-core/CONTRIBUTING.md
@@ -13,6 +13,9 @@ Contributing to the project, especially `regexes.yaml`, is both welcomed and enc
 5. Push your branch to GitHub and submit a pull request
 6. Monitor the pull request to make sure the Travis build succeeds. If it fails simply make the necessary changes to your branch and push it. Travis will re-test the changes.
 
+If you wish to update uap-core to latest master, simply run the following command and then submit a pull request with the result:
+`git subtree pull --prefix uap-core https://github.com/ua-parser/uap-core.git master --squash`
+
 That's it. If you don't feel comfortable forking the project or modifying the YAML you can also [submit an issue](https://github.com/ua-parser/uap-core/issues) that includes the appropriate user agent string and the expected results of parsing.
 
 Thanks!

--- a/uap-core/README.md
+++ b/uap-core/README.md
@@ -1,4 +1,4 @@
-uap-core [![Build Status](https://secure.travis-ci.org/ua-parser/uap-core.png?branch=master)](https://travis-ci.org/ua-parser/uap-core)
+uap-core [![Build Status](https://secure.travis-ci.org/ua-parser/uap-core.svg?branch=master)](https://travis-ci.org/ua-parser/uap-core)
 ========
 
 This repository contains the core of [BrowserScope][2]'s original [user agent string parser][3]: data collected over the years by [Steve Souders][4] and numerous other contributors, extracted into a separate [YAML file][5] so as to be reusable _as is_ by implementations in any programming language.

--- a/uap-core/regexes.yaml
+++ b/uap-core/regexes.yaml
@@ -17,6 +17,10 @@ user_agent_parsers:
   - regex: 'Google.*/\+/web/snippet'
     family_replacement: 'GooglePlusBot'
 
+  # Twitter
+  - regex: '(Twitterbot)/(\d+)\.(\d+)'
+    family_replacement: 'TwitterBot'
+
   # Bots Pattern '/name-0.0'
   - regex: '/((?:Ant-)?Nutch|[A-z]+[Bb]ot|[A-z]+[Ss]pider|Axtaris|fetchurl|Isara|ShopSalad|Tailsweep)[ \-](\d+)(?:\.(\d+)(?:\.(\d+))?)?'
   # Bots Pattern 'name/0.0'
@@ -30,7 +34,7 @@ user_agent_parsers:
   - regex: '(Google-HTTP-Java-Client|Apache-HttpClient|http%20client|Python-urllib|HttpMonitor|TLSProber|WinHTTP|JNLP)(?:[ /](\d+)(?:\.(\d+)(?:\.(\d+))?)?)?'
 
   # Bots
-  - regex: '(1470\.net crawler|50\.nu|8bo Crawler Bot|Aboundex|Accoona-[A-z]+-Agent|AdsBot-Google(?:-[a-z]+)?|altavista|AppEngine-Google|archive.*?\.org_bot|archiver|Ask Jeeves|[Bb]ai[Dd]u[Ss]pider(?:-[A-Za-z]+)*|bingbot|BingPreview|blitzbot|BlogBridge|BoardReader(?: [A-Za-z]+)*|boitho.com-dc|BotSeer|\b\w*favicon\w*\b|\bYeti(?:-[a-z]+)?|Catchpoint bot|[Cc]harlotte|Checklinks|clumboot|Comodo HTTP\(S\) Crawler|Comodo-Webinspector-Crawler|ConveraCrawler|CRAWL-E|CrawlConvera|Daumoa(?:-feedfetcher)?|Feed Seeker Bot|findlinks|Flamingo_SearchEngine|FollowSite Bot|furlbot|Genieo|gigabot|GomezAgent|gonzo1|(?:[a-zA-Z]+-)?Googlebot(?:-[a-zA-Z]+)?|Google SketchUp|grub-client|gsa-crawler|heritrix|HiddenMarket|holmes|HooWWWer|htdig|ia_archiver|ICC-Crawler|Icarus6j|ichiro(?:/mobile)?|IconSurf|IlTrovatore(?:-Setaccio)?|InfuzApp|Innovazion Crawler|InternetArchive|IP2[a-z]+Bot|jbot\b|KaloogaBot|Kraken|Kurzor|larbin|LEIA|LesnikBot|Linguee Bot|LinkAider|LinkedInBot|Lite Bot|Llaut|lycos|Mail\.RU_Bot|masidani_bot|Mediapartners-Google|Microsoft .*? Bot|mogimogi|mozDex|MJ12bot|msnbot(?:-media *)?|msrbot|netresearch|Netvibes|NewsGator[^/]*|^NING|Nutch[^/]*|Nymesis|ObjectsSearch|Orbiter|OOZBOT|PagePeeker|PagesInventory|PaxleFramework|Peeplo Screenshot Bot|PlantyNet_WebRobot|Pompos|Read%20Later|Reaper|RedCarpet|Retreiver|Riddler|Riddler|Rival IQ|scooter|Scrapy|Scrubby|searchsight|seekbot|semanticdiscovery|Simpy|SimplePie|SEOstats|SimpleRSS|SiteCon|Slurp|snappy|Speedy Spider|Squrl Java|TheUsefulbot|ThumbShotsBot|Thumbshots\.ru|TwitterBot|URL2PNG|Vagabondo|VoilaBot|^vortex|Votay bot|^voyager|WASALive.Bot|Web-sniffer|WebThumb|WeSEE:[A-z]+|WhatWeb|WIRE|WordPress|Wotbox|www\.almaden\.ibm\.com|Xenu(?:.s)? Link Sleuth|Xerka [A-z]+Bot|yacy(?:bot)?|Yahoo[a-z]*Seeker|Yahoo! Slurp|Yandex\w+|YodaoBot(?:-[A-z]+)?|YottaaMonitor|Yowedo|^Zao|^Zao-Crawler|ZeBot_www\.ze\.bz|ZooShot|ZyBorg)(?:[ /]v?(\d+)(?:\.(\d+)(?:\.(\d+))?)?)?'
+  - regex: '(1470\.net crawler|50\.nu|8bo Crawler Bot|Aboundex|Accoona-[A-z]+-Agent|AdsBot-Google(?:-[a-z]+)?|altavista|AppEngine-Google|archive.*?\.org_bot|archiver|Ask Jeeves|[Bb]ai[Dd]u[Ss]pider(?:-[A-Za-z]+)*|bingbot|BingPreview|blitzbot|BlogBridge|BoardReader(?: [A-Za-z]+)*|boitho.com-dc|BotSeer|\b\w*favicon\w*\b|\bYeti(?:-[a-z]+)?|Catchpoint bot|[Cc]harlotte|Checklinks|clumboot|Comodo HTTP\(S\) Crawler|Comodo-Webinspector-Crawler|ConveraCrawler|CRAWL-E|CrawlConvera|Daumoa(?:-feedfetcher)?|Feed Seeker Bot|findlinks|Flamingo_SearchEngine|FollowSite Bot|furlbot|Genieo|gigabot|GomezAgent|gonzo1|(?:[a-zA-Z]+-)?Googlebot(?:-[a-zA-Z]+)?|Google SketchUp|grub-client|gsa-crawler|heritrix|HiddenMarket|holmes|HooWWWer|htdig|ia_archiver|ICC-Crawler|Icarus6j|ichiro(?:/mobile)?|IconSurf|IlTrovatore(?:-Setaccio)?|InfuzApp|Innovazion Crawler|InternetArchive|IP2[a-z]+Bot|jbot\b|KaloogaBot|Kraken|Kurzor|larbin|LEIA|LesnikBot|Linguee Bot|LinkAider|LinkedInBot|Lite Bot|Llaut|lycos|Mail\.RU_Bot|masidani_bot|Mediapartners-Google|Microsoft .*? Bot|mogimogi|mozDex|MJ12bot|msnbot(?:-media *)?|msrbot|netresearch|Netvibes|NewsGator[^/]*|^NING|Nutch[^/]*|Nymesis|ObjectsSearch|Orbiter|OOZBOT|PagePeeker|PagesInventory|PaxleFramework|Peeplo Screenshot Bot|PlantyNet_WebRobot|Pompos|Read%20Later|Reaper|RedCarpet|Retreiver|Riddler|Rival IQ|scooter|Scrapy|Scrubby|searchsight|seekbot|semanticdiscovery|Simpy|SimplePie|SEOstats|SimpleRSS|SiteCon|Slurp|snappy|Speedy Spider|Squrl Java|TheUsefulbot|ThumbShotsBot|Thumbshots\.ru|TwitterBot|URL2PNG|Vagabondo|VoilaBot|^vortex|Votay bot|^voyager|WASALive.Bot|Web-sniffer|WebThumb|WeSEE:[A-z]+|WhatWeb|WIRE|WordPress|Wotbox|www\.almaden\.ibm\.com|Xenu(?:.s)? Link Sleuth|Xerka [A-z]+Bot|yacy(?:bot)?|Yahoo[a-z]*Seeker|Yahoo! Slurp|Yandex\w+|YodaoBot(?:-[A-z]+)?|YottaaMonitor|Yowedo|^Zao|^Zao-Crawler|ZeBot_www\.ze\.bz|ZooShot|ZyBorg)(?:[ /]v?(\d+)(?:\.(\d+)(?:\.(\d+))?)?)?'
 
   # Bots General matcher 'name/0.0'
   - regex: '(?:\/[A-Za-z0-9\.]+)? *([A-Za-z0-9 \-_\!\[\]:]*(?:[Aa]rchiver|[Ii]ndexer|[Ss]craper|[Bb]ot|[Ss]pider|[Cc]rawl[a-z]*))/(\d+)(?:\.(\d+)(?:\.(\d+))?)?'
@@ -47,6 +51,14 @@ user_agent_parsers:
   # must go before Firefox to catch Chimera/SeaMonkey/Camino
   - regex: '(Chimera|SeaMonkey|Camino)/(\d+)\.(\d+)\.?([ab]?\d+[a-z]*)?'
 
+  # Social Networks
+  # Facebook
+  - regex: '\[FB.*;(FBAV)/(\d+)(?:\.(\d+)(?:\.(\d)+)?)?'
+    family_replacement: 'Facebook'
+  # Pinterest
+  - regex: '\[(Pinterest)/[^\]]+\]'
+  - regex: '(Pinterest)(?: for Android(?: Tablet)?)?/(\d+)(?:\.(\d+)(?:\.(\d)+)?)?'
+
   # Firefox
   - regex: '(Pale[Mm]oon)/(\d+)\.(\d+)\.?(\d+)?'
     family_replacement: 'Pale Moon (Firefox Variant)'
@@ -56,7 +68,7 @@ user_agent_parsers:
     family_replacement: 'Firefox Mobile'
   - regex: '(Fennec)/(\d+)\.(\d+)'
     family_replacement: 'Firefox Mobile'
-  - regex: 'Mobile.*(Firefox)/(\d+)\.(\d+)'
+  - regex: '(?:Mobile|Tablet);.*(Firefox)/(\d+)\.(\d+)'
     family_replacement: 'Firefox Mobile'
   - regex: '(Namoroka|Shiretoko|Minefield)/(\d+)\.(\d+)\.(\d+(?:pre)?)'
     family_replacement: 'Firefox ($1)'
@@ -98,6 +110,7 @@ user_agent_parsers:
   # Opera will stop at 9.80 and hide the real version in the Version string.
   # see: http://dev.opera.com/articles/view/opera-ua-string-changes/
   - regex: '(Opera Tablet).*Version/(\d+)\.(\d+)(?:\.(\d+))?'
+  - regex: '(Opera Mini)(?:/att)?/?(\d+)?(?:\.(\d+))?(?:\.(\d+))?'
   - regex: '(Opera)/.+Opera Mobi.+Version/(\d+)\.(\d+)'
     family_replacement: 'Opera Mobile'
   - regex: '(Opera)/(\d+)\.(\d+).+Opera Mobi'
@@ -106,7 +119,6 @@ user_agent_parsers:
     family_replacement: 'Opera Mobile'
   - regex: 'Opera Mobi'
     family_replacement: 'Opera Mobile'
-  - regex: '(Opera Mini)(?:/att)?/(\d+)\.(\d+)'
   - regex: '(Opera)/9.80.*Version/(\d+)\.(\d+)(?:\.(\d+))?'
 
   # Opera 14 for Android uses a WebKit render engine.
@@ -193,6 +205,14 @@ user_agent_parsers:
   # @ref: http://www.puffinbrowser.com
   - regex: '(Puffin)/(\d+)\.(\d+)(?:\.(\d+))?'
 
+  # Edge Mobile
+  - regex: 'Windows Phone .*(Edge)/(\d+)\.(\d+)'
+    family_replacement: 'Edge Mobile'
+
+  # Samsung Internet (based on Chrome, but lacking some features)
+  - regex: '(SamsungBrowser)/(\d+)\.(\d+)'
+    family_replacement: 'Samsung Internet'
+
   # Chrome Mobile
   - regex: '(CrMo)/(\d+)\.(\d+)\.(\d+)\.(\d+)'
     family_replacement: 'Chrome Mobile'
@@ -260,12 +280,12 @@ user_agent_parsers:
   - regex: '(AdobeAIR|FireWeb|Jasmine|ANTGalio|Midori|Fresco|Lobo|PaleMoon|Maxthon|Lynx|OmniWeb|Dillo|Camino|Demeter|Fluid|Fennec|Epiphany|Shiira|Sunrise|Spotify|Flock|Netscape|Lunascape|WebPilot|NetFront|Netfront|Konqueror|SeaMonkey|Kazehakase|Vienna|Iceape|Iceweasel|IceWeasel|Iron|K-Meleon|Sleipnir|Galeon|GranParadiso|Opera Mini|iCab|NetNewsWire|ThunderBrowse|Iris|UP\.Browser|Bunjalloo|Google Earth|Raven for Mac|Openwave)/(\d+)\.(\d+)\.(\d+)'
 
   # Outlook 2007
-  - regex: 'MSOffice 12'
+  - regex: 'Microsoft Office Outlook 12\.\d+\.\d+|MSOffice 12'
     family_replacement: 'Outlook'
     v1_replacement: '2007'
 
   # Outlook 2010
-  - regex: 'MSOffice 14'
+  - regex: 'Microsoft Outlook 14\.\d+\.\d+|MSOffice 14'
     family_replacement: 'Outlook'
     v1_replacement: '2010'
 
@@ -273,6 +293,11 @@ user_agent_parsers:
   - regex: 'Microsoft Outlook 15\.\d+\.\d+'
     family_replacement: 'Outlook'
     v1_replacement: '2013'
+
+  # Outlook 2016
+  - regex: 'Microsoft Outlook (?:Mail )?16\.\d+\.\d+'
+    family_replacement: 'Outlook'
+    v1_replacement: '2016'
 
   # Apple Air Mail
   - regex: '(Airmail) (\d+)\.(\d+)(?:\.(\d+))?'
@@ -287,6 +312,10 @@ user_agent_parsers:
   # Edge/major_version.minor_version
   - regex: '(Edge)/(\d+)\.(\d+)'
 
+  # Brave Browser https://brave.com/
+  - regex: '(brave)/(\d+)\.(\d+)\.(\d+) Chrome'
+    family_replacement: 'Brave'
+
   # Chrome/Chromium/major_version.minor_version.beta_version
   - regex: '(Chromium|Chrome)/(\d+)\.(\d+)\.(\d+)'
 
@@ -295,7 +324,7 @@ user_agent_parsers:
   - regex: '\b(Dolphin)(?: |HDCN/|/INT\-)(\d+)\.(\d+)\.?(\d+)?'
 
   # Browser/major_version.minor_version
-  - regex: '(bingbot|Bolt|Jasmine|IceCat|Skyfire|Midori|Maxthon|Lynx|Arora|IBrowse|Dillo|Camino|Shiira|Fennec|Phoenix|Chrome|Flock|Netscape|Lunascape|Epiphany|WebPilot|Opera Mini|Opera|NetFront|Netfront|Konqueror|Googlebot|SeaMonkey|Kazehakase|Vienna|Iceape|Iceweasel|IceWeasel|Iron|K-Meleon|Sleipnir|Galeon|GranParadiso|iCab|iTunes|MacAppStore|NetNewsWire|Space Bison|Stainless|Orca|Dolfin|BOLT|Minimo|Tizen Browser|Polaris|Abrowser|Planetweb|ICE Browser|mDolphin)/(\d+)\.(\d+)\.?(\d+)?'
+  - regex: '(bingbot|Bolt|Jasmine|IceCat|Skyfire|Midori|Maxthon|Lynx|Arora|IBrowse|Dillo|Camino|Shiira|Fennec|Phoenix|Chrome|Flock|Netscape|Lunascape|Epiphany|WebPilot|Opera Mini|Opera|NetFront|Netfront|Konqueror|Googlebot|SeaMonkey|Kazehakase|Vienna|Iceape|Iceweasel|IceWeasel|Iron|K-Meleon|Sleipnir|Galeon|GranParadiso|iCab|iTunes|MacAppStore|NetNewsWire|Space Bison|Stainless|Orca|Dolfin|BOLT|Minimo|Tizen Browser|Polaris|Abrowser|Planetweb|ICE Browser|mDolphin|qutebrowser|Otter|QupZilla)/(\d+)\.(\d+)\.?(\d+)?'
 
   # Chrome/Chromium/major_version.minor_version
   - regex: '(Chromium|Chrome)/(\d+)\.(\d+)'
@@ -373,22 +402,18 @@ user_agent_parsers:
     family_replacement: 'Bon Echo'
 
   # @note: iOS / OSX Applications
-  - regex: '(iPod).+Version/(\d+)\.(\d+)\.(\d+)'
+  - regex: '(iPod|iPhone|iPad).+Version/(\d+)\.(\d+)(?:\.(\d+))?.* Safari'
     family_replacement: 'Mobile Safari'
-  - regex: '(iPod).*Version/(\d+)\.(\d+)'
-    family_replacement: 'Mobile Safari'
-  - regex: '(iPhone).*Version/(\d+)\.(\d+)\.(\d+)'
-    family_replacement: 'Mobile Safari'
-  - regex: '(iPhone).*Version/(\d+)\.(\d+)'
-    family_replacement: 'Mobile Safari'
-  - regex: '(iPad).*Version/(\d+)\.(\d+)\.(\d+)'
-    family_replacement: 'Mobile Safari'
-  - regex: '(iPad).*Version/(\d+)\.(\d+)'
+  - regex: '(iPod|iPhone|iPad).+Version/(\d+)\.(\d+)(?:\.(\d+))?'
+    family_replacement: 'Mobile Safari UI/WKWebView'
+  - regex: '(iPod|iPhone|iPad);.*CPU.*OS (\d+)_(\d+)(?:_(\d+))?.*Mobile.* Safari'
     family_replacement: 'Mobile Safari'
   - regex: '(iPod|iPhone|iPad);.*CPU.*OS (\d+)_(\d+)(?:_(\d+))?.*Mobile'
+    family_replacement: 'Mobile Safari UI/WKWebView'
+  - regex: '(iPod|iPhone|iPad).* Safari'
     family_replacement: 'Mobile Safari'
   - regex: '(iPod|iPhone|iPad)'
-    family_replacement: 'Mobile Safari'
+    family_replacement: 'Mobile Safari UI/WKWebView'
 
   - regex: '(AvantGo) (\d+).(\d+)'
 
@@ -429,11 +454,9 @@ user_agent_parsers:
   - regex: '(Nokia)[EN]?(\d+)'
 
   # BlackBerry devices
-  - regex: '(BB10);'
-    family_replacement: 'BlackBerry WebKit'
   - regex: '(PlayBook).+RIM Tablet OS (\d+)\.(\d+)\.(\d+)'
     family_replacement: 'BlackBerry WebKit'
-  - regex: '(Black[bB]erry).+Version/(\d+)\.(\d+)\.(\d+)'
+  - regex: '(Black[bB]erry|BB10).+Version/(\d+)\.(\d+)\.(\d+)'
     family_replacement: 'BlackBerry WebKit'
   - regex: '(Black[bB]erry)\s?(\d+)'
     family_replacement: 'BlackBerry'
@@ -507,6 +530,9 @@ user_agent_parsers:
     family_replacement: 'Python Requests'
 
   - regex: '(Java)[/ ]{0,1}\d+\.(\d+)\.(\d+)[_-]*([a-zA-Z0-9]+)*'
+
+  # Roku Digital-Video-Players https://www.roku.com/
+  - regex: '^(Roku)/DVP-(\d+)\.(\d+)'
 
 os_parsers:
   ##########
@@ -825,6 +851,12 @@ os_parsers:
     os_replacement: 'iOS'
 
   ##########
+  # Apple TV
+  ##########
+  - regex: '(tvOS)/(\d+).(\d+)'
+    os_replacement: 'tvOS'
+
+  ##########
   # Chrome OS
   # if version 0.0.0, probably this stuff:
   # http://code.google.com/p/chromium-os/issues/detail?id=11573
@@ -963,11 +995,14 @@ os_parsers:
 
   # just os
   - regex: '(Windows|Android|WeTab|Maemo)'
-  - regex: '(Ubuntu|Kubuntu|Arch Linux|CentOS|Slackware|Gentoo|openSUSE|SUSE|Red Hat|Fedora|PCLinuxOS|Gentoo|Mageia|(?:Free|Open|Net|\b)BSD)'
+  - regex: '(Ubuntu|Kubuntu|Arch Linux|CentOS|Slackware|Gentoo|openSUSE|SUSE|Red Hat|Fedora|PCLinuxOS|Mageia|(?:Free|Open|Net|\b)BSD)'
   # Linux + Kernel Version
   - regex: '(Linux)(?:[ /](\d+)\.(\d+)(?:\.(\d+))?)?'
   - regex: 'SunOS'
     os_replacement: 'Solaris'
+
+  # Roku Digital-Video-Players https://www.roku.com/
+  - regex: '^(Roku)/DVP-(\d+)\.(\d+)'
 
 device_parsers:
 
@@ -3829,7 +3864,7 @@ device_parsers:
   # XiaoMi
   # @ref: http://www.xiaomi.com/event/buyphone
   #########
-  - regex: '; *(MI \d[^;/]*|MI-ONE Plus) Build/'
+  - regex: '; *((MI|HM|MI-ONE|Redmi)[ -](NOTE |Note )?[^;/]*) Build/'
     device_replacement: 'XiaoMi $1'
     brand_replacement: 'XiaoMi'
     model_replacement: '$1'
@@ -4686,6 +4721,10 @@ device_parsers:
   # WebTV
   ##########
   - regex: '(WebTV)/\d+.\d+'
+    brand_replacement: 'Generic_Inettv'
+    model_replacement: '$1'
+  # Roku Digital-Video-Players https://www.roku.com/
+  - regex: '^(Roku)/DVP-\d+\.\d+'
     brand_replacement: 'Generic_Inettv'
     model_replacement: '$1'
 

--- a/uap-core/test_resources/opera_mini_user_agent_strings.yaml
+++ b/uap-core/test_resources/opera_mini_user_agent_strings.yaml
@@ -1,0 +1,1224 @@
+# Additional tests for opera mini detection.
+# List of user agent strings and corresponding versions is taken from http://www.useragentstring.com/pages/Opera%20Mini/
+# Some user agent string are from http://www.webapps-online.com/online-tools/user-agent-strings/dv/plugin55599/opera-mini
+
+test_cases:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/9.80 (S60; SymbOS; Opera Mobi/23.348; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '9'
+    minor: '80'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/9.80 (S60; SymbOS; Opera Mobi/23.334; U; id) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '9'
+    minor: '80'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/9.80 (J2ME/23.377; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '9'
+    minor: '80'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/9.80 (J2ME/22.478; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '9'
+    minor: '80'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/9 (Compatible; MSIE:9.0; iPhone; BlackBerry9700; AppleWebKit/24.746; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '9'
+    minor:
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (Android; Opera Mini/7.6.35766/35.5706; U; en) Presto/2.8.119 Version/11.10'
+    family: 'Opera Mini'
+    major: '7'
+    minor: '6'
+    patch: '35766'
+
+  - user_agent_string: 'Opera/9.80 (Android; Opera Mini/7.5.33361/31.1350; U; en) Presto/2.8.119 Version/11.10'
+    family: 'Opera Mini'
+    major: '7'
+    minor: '5'
+    patch: '33361'
+
+  - user_agent_string: 'Opera/9.80 (Android; Opera Mini/7.29530/27.1407; U; en) Presto/2.8.119 Version/11.10'
+    family: 'Opera Mini'
+    major: '7'
+    minor: '29530'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (iPhone; Opera Mini/7.1.32694/27.1407; U; en) Presto/2.8.119 Version/11.10'
+    family: 'Opera Mini'
+    major: '7'
+    minor: '1'
+    patch: '32694'
+
+  - user_agent_string: 'Opera/9.80 (iPad; Opera Mini/7.1.32694/27.1407; U; en) Presto/2.8.119 Version/11.10'
+    family: 'Opera Mini'
+    major: '7'
+    minor: '1'
+    patch: '32694'
+
+  - user_agent_string: 'Opera/9.80 (Series 60; Opera Mini/7.1.32444/35.5706; U; en) Presto/2.8.119 Version/11.10'
+    family: 'Opera Mini'
+    major: '7'
+    minor: '1'
+    patch: '32444'
+
+  - user_agent_string: 'Opera/9.80 (Series 60; Opera Mini/7.1.32444/35.2883; U; ru) Presto/2.8.119 Version/11.10'
+    family: 'Opera Mini'
+    major: '7'
+    minor: '1'
+    patch: '32444'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/7.1.32052/35.5706; U; id) Presto/2.8.119 Version/11.10'
+    family: 'Opera Mini'
+    major: '7'
+    minor: '1'
+    patch: '32052'
+
+  - user_agent_string: 'Opera/9.80 (iPhone; Opera Mini/7.0.4/28.2555; U; fr) Presto/2.8.119 Version/11.10'
+    family: 'Opera Mini'
+    major: '7'
+    minor: '0'
+    patch: '4'
+
+  - user_agent_string: 'Opera/9.80 (Android; Opera Mini/7.0.29952/28.2075; U; es) Presto/2.8.119 Version/11.10'
+    family: 'Opera Mini'
+    major: '7'
+    minor: '0'
+    patch: '29952'
+
+  - user_agent_string: 'Opera/9.80 (Series 60; Opera Mini/6.5.29702/28.2647; U; es) Presto/2.8.119 Version/11.10'
+    family: 'Opera Mini'
+    major: '6'
+    minor: '5'
+    patch: '29702'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/6.5.26955/27.1407; U; en) Presto/2.8.119 Version/11.10'
+    family: 'Opera Mini'
+    major: '6'
+    minor: '5'
+    patch: '26955'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/6.24288/25.729; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '6'
+    minor: '24288'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (BlackBerry; Opera Mini/6.24209/27.1366; U; en) Presto/2.8.119 Version/11.10'
+    family: 'Opera Mini'
+    major: '6'
+    minor: '24209'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (Series 60; Opera Mini/6.24096/25.657; U; id) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '6'
+    minor: '24096'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/6.24093/26.1305; U; en) Presto/2.8.119 Version/10.54'
+    family: 'Opera Mini'
+    major: '6'
+    minor: '24093'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/6.24093/25.657; U; id) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '6'
+    minor: '24093'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (Series 60; Opera Mini/6.1.25759/25.872; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '6'
+    minor: '1'
+    patch: '25759'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/6.1.25378/25.677; U; th) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '6'
+    minor: '1'
+    patch: '25378'
+
+  - user_agent_string: 'Opera/9.80 (Android; Opera Mini/6.1.25375/25.657; U; es) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '6'
+    minor: '1'
+    patch: '25375'
+
+  - user_agent_string: 'Opera/9.80 (Series 60; Opera Mini/6.0.24455/28.2766; U; en) Presto/2.8.119 Version/11.10'
+    family: 'Opera Mini'
+    major: '6'
+    minor: '0'
+    patch: '24455'
+
+  - user_agent_string: 'Opera/9.80 (Android;Opera Mini/6.0.24212/24.746 U;en) Presto/2.5.25 Version/10.5454'
+    family: 'Opera Mini'
+    major: '6'
+    minor: '0'
+    patch: '24212'
+
+  - user_agent_string: 'Opera/9.80 (Series 60; Opera Mini/6.0.24095/24.760; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '6'
+    minor: '0'
+    patch: '24095'
+
+  - user_agent_string: 'Opera/9.80 (Series 60; Opera Mini/6.0.24095/24.741; U; zh) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '6'
+    minor: '0'
+    patch: '24095'
+
+  - user_agent_string: 'Opera/9.80 (Series 60; Opera Mini/5.1.22784/23.334; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '1'
+    patch: '22784'
+
+  - user_agent_string: 'Opera/9.80 (Series 60; Opera Mini/5.1.22784/22.394; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '1'
+    patch: '22784'
+
+  - user_agent_string: 'Opera/9.80 (Series 60; Opera Mini/5.1.22784/22.387; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '1'
+    patch: '22784'
+
+  - user_agent_string: 'Opera/9.80 (Series 60; Opera Mini/5.1.22783/23.334; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '1'
+    patch: '22783'
+
+  - user_agent_string: 'Opera/9.80 (Series 60; Opera Mini/5.1.22783/22.478; U; id) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '1'
+    patch: '22783'
+
+  - user_agent_string: 'Opera/9.80 (Series 60; Opera Mini/5.1.22783/22.478; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '1'
+    patch: '22783'
+
+  - user_agent_string: 'Opera/9.80 (Android; Opera Mini/5.1.22460/23.334; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '1'
+    patch: '22460'
+
+  - user_agent_string: 'Opera/9.80 (Android; Opera Mini/5.1.22460/22.478; U; fr) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '1'
+    patch: '22460'
+
+  - user_agent_string: 'Opera/9.80 (Android; Opera Mini/5.1.22460/22.414; U; de) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '1'
+    patch: '22460'
+
+  - user_agent_string: 'Opera/9.80 (Series 60; Opera Mini/5.1.22396/22.478; U; id) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '1'
+    patch: '22396'
+
+  - user_agent_string: 'Opera/9.80 (BlackBerry; Opera Mini/5.1.22303/22.387; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '1'
+    patch: '22303'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.1.22296; BlackBerry9800; U; AppleWebKit/23.370; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '1'
+    patch: '22296'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.1.22296/22.87; U; fr) Presto/2.5.25'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '1'
+    patch: '22296'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.1.22296/22.87; U; en) Presto/2.5.25'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '1'
+    patch: '22296'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.1.22296/22.478; U; fr) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '1'
+    patch: '22296'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.1.22296/22.387; U; fr) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '1'
+    patch: '22296'
+
+  - user_agent_string: 'Opera/9.50 (J2ME/MIDP; Opera Mini/5.1.21965/20.2513; U; en)'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '1'
+    patch: '21965'
+
+  - user_agent_string: 'Opera/9.80 (Windows Mobile; Opera Mini/5.1.21595/25.657; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '1'
+    patch: '21595'
+
+  - user_agent_string: 'Opera/9.80 (Windows Mobile; Opera Mini/5.1.21594/22.387; U; ru) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '1'
+    patch: '21594'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.1.21415/22.387; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '1'
+    patch: '21415'
+
+  - user_agent_string: 'Opera/10.61 (J2ME/MIDP; Opera Mini/5.1.21219/19.999; en-US; rv:1.9.3a5) WebKit/534.5 Presto/2.6.30'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '1'
+    patch: '21219'
+
+  - user_agent_string: 'Opera/9.80(J2ME/MIDP; Opera Mini/5.1.21214/22.414; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '1'
+    patch: '21214'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.1.21214/22.414; U; ro) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '1'
+    patch: '21214'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.1.21214/22.387; U; id) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '1'
+    patch: '21214'
+
+  - user_agent_string: 'Opera/9.80 (Android; Opera Mini/5.1.21126/19.892; U; de) Presto/2.5.25'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '1'
+    patch: '21126'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.1.21051/27.1573; U; en) Presto/2.8.119 Version/11.10'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '1'
+    patch: '21051'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.1.21051/23.377; U; id) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '1'
+    patch: '21051'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.1.21051/20.2477; U; en) Presto/2.5.25'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '1'
+    patch: '21051'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0.3521/886; U; en) Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch: '3521'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0.3521/22.414; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch: '3521'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0.3521/18.684; U; en) Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch: '3521'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0.22349/37.6584; U; en) Presto/2.12.423 Version/12.16'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch: '22349'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0.20873/19.916; U; en) Presto/2.5.25'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch: '20873'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0.19693Mod.by.Handler/23.390; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch: '19693'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0.19693Mod.by.Handler/18.794; U; id) Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch: '19693'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0.19693/870; U; en) Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch: '19693'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0.19683/1278; U; ko) Presto/2.2.0'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch: '19683'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0.18741Mod.by.Handler/22.414; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch: '18741'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0.18741/886; U; id) Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch: '18741'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0.18741/886; U; en) Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch: '18741'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0.18741/870; U; fr) Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch: '18741'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0.18741/870; U; en) Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch: '18741'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0.18741/18.794; U; en) Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch: '18741'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0.18635Mod.by.Handler/23.377; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch: '18635'
+
+  - user_agent_string: 'Opera/9.80 (Windows NT 5.1; U; Opera/9.80 (J2ME/MIDP; Opera Mini/5.0.18635/1030; U; en) Presto/2.4.15; ru) Presto/2.8.99 Version/11.10'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch: '18635'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0.18635/886; U; en) Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch: '18635'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0.17443/886; U; en) Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch: '17443'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0.17443/20.2477; U; en) Presto/2.5.25'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch: '17443'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0.17381/886; U; en) Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch: '17381'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0.16823Mod.by.Handler/22.387; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch: '16823'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0.16823/870; U; en) Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch: '16823'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0.15650/20.2479; U; en) Presto/2.5.25'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch: '15650'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/iPhone;Opera Mini/5.0.019802/886; U; ja)Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch: '019802'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/iPhone;Opera Mini/5.0.019802/886; U; ja)Presto/ 2.4.15'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch: '019802'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/iPhone;Opera Mini/5.0.019802/886; U; ja) Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch: '019802'
+
+  - user_agent_string: 'Opera/9.80 (iPhone; Opera Mini/5.0.019802/886; U; ja) Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch: '019802'
+
+  - user_agent_string: 'Opera/9.80 (iPhone; Opera Mini/5.0.019802/886; U; en) Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch: '019802'
+
+  - user_agent_string: 'Opera/9.80 (iPhone; Opera Mini/5.0.019802/22.414; U; de) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch: '019802'
+
+  - user_agent_string: 'Opera/9.80 (iPhone; Opera Mini/5.0.019802/18.738; U; en) Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch: '019802'
+
+  - user_agent_string: 'Opera/9.80 (iPhone; Opera Mini/5.0.0176/764; U; en) Presto/2.4.154.15'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch: '0176'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0.0.862 Profile/24.743; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch: '0'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0.0.423 Profile/18.684; U; en) Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch: '0'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0.0.351 Profile/22.478; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch: '0'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0/870; U; en) Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0(Windows; U; Windows NT 5.1; en-US)/23.390; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0 (Windows; U; Windows NT 6.1; sv-SE) AppleWebKit/23.411; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0 (Windows; U; Windows NT 6.1; rv:2.2) Gecko/24.838; U; id) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0 (Windows; U; Windows NT 6.1; en-US) AppleWebKit/23.411; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0 (Windows; U; Windows NT 6.1; en-US) AppleWebKit/22.478; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0 (Windows; U; Windows NT 5.1; de; rv:1.9.2.3) Gecko/23.377; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0 (Windows NT 6.1; WOW64) AppleWebKit/23.411; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0 (SymbianOS/24.838; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0 (Linux; U; Android 2.2; fr-lu; HTC Legend Build/24.838; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0 (Linux; U; Android 2.2; en-sa; HTC_DesireHD_A9191 Build/24.741; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0 (iPhone; U; xxxx like Mac OS X; en) AppleWebKit/24.838; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0 (iPhone; U; fr; CPU iPhone OS 4_2_1 like Mac OS X; fr) AppleWebKit/23.405; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0 (iPhone; U; CPU iPhone OS 3_0 like Mac OS X; en-us) AppleWebKit/23.411; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0 (iPhone; U; CPU iPhone OS 3_0 like Mac OS X; en-us) AppleWebKit/23.377; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0 (BlackBerry; U; BlackBerry9800; en-GB) AppleWebKit/24.783; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0 (BlackBerry; U; BlackBerry 9800) AppleWebKit/24.783; U; es) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.5.33867/35.2883; U; en) Presto/2.8.119 Version/11.10'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '5'
+    patch: '33867'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.4.Vista/19.916; U; en) Presto/2.5.25'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '4'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.4.29476/27.1573; U; id) Presto/2.8.119 Version/11.10'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '4'
+    patch: '29476'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.4.26736/28.2647; U; it) Presto/2.8.119 Version/11.10'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '4'
+    patch: '26736'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.4.0.60 (Windows XP)/886; U; en) Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '4'
+    patch: '0'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.3.24214; iPhone; CPU iPhone OS 4_2_1 like Mac OS X; AppleWebKit/24.783; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '3'
+    patch: '24214'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.3.24214/27.1407; U; id) Presto/2.8.119 Version/11.10'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '3'
+    patch: '24214'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.3.24214 (Windows; U; Windows NT 6.1) AppleWebKit/24.838; U; id) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '3'
+    patch: '24214'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.3.13337/25.657; U; ro) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '3'
+    patch: '13337'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.24721/30.3316; U; en) Presto/2.8.119 Version/11.10'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '24721'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.23453/28.2647; U; en) Presto/2.8.119 Version/11.10'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '23453'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.21465/22.478; U; id) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '21465'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.21465/22.387; U; id) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '21465'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.19634/23.333; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '19634'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.18887/22.478; U; id) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '18887'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.16320/29.3594; U; en) Presto/2.8.119 Version/11.10'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '16320'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.16007Mod.by.Handler/23.390; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '16007'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.15410QUAIN/22.478; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '15410'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.15410Mod.by.Handler/23.334; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '15410'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.15410Mod.by.Handler/23.333; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '15410'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.15410Mod.by.Handler/22.401; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '15410'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.15410Mod.by.Handler/20.2485; U; en) Presto/2.5.25'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '15410'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.15410Mod.by.Handler/18.678; U; en) Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '15410'
+
+  - user_agent_string: 'Opera/9.60 (J2ME/MIDP;Opera Mini/4.2.15410Mod.by.Handler/503; U; en)Presto/2.2.0'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '15410'
+
+  - user_agent_string: 'Opera/9.50 (J2ME/MIDP; Opera Mini/4.2.15410Mod.by.Handler/20.2590; U; en)'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '15410'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.15410/870; U; en) Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '15410'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.15410/24.899; U; id) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '15410'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.15410/22.394; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '15410'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.15066/886; U; en) Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '15066'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.14912mod.By.onome/22.401; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '14912'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.14912Mod.by.Handler/24.783; U; id) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '14912'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.14912Mod.by.Handler/23.377; U; id) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '14912'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.14912Mod.By.www.9jamusic.cz.cc/22.387; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '14912'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.14912/870; U; id) Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '14912'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.14912/35.5706; U; id) Presto/2.8.119 Version/11.10'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '14912'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.14912/24.746; U; id) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '14912'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.14912/23.334; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '14912'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.14912/23.333; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '14912'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.14912/22.394; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '14912'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.14885/20.2485; U; zh) Presto/2.5.25'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '14885'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.14881Mod.by.Handler/24.743; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '14881'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.14881Mod.by.Handler/23.317; U; id) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '14881'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.14753/20.2485; U; zh) Presto/2.5.25'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '14753'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.14409/20.2485; U; zh) Presto/2.5.25'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '14409'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.14320/886; U; id) Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '14320'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.14320/22.478; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '14320'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.14320/20.2485; U; zh) Presto/2.5.25'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '14320'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.13943/20.2485; U; zh) Presto/2.5.25'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '13943'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.13918/22.414; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '13918'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.13400/20.2485; U; zh) Presto/2.5.25'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '13400'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.13337.Mod.by.Handler/870; U; en) Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '13337'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.13337/886; U; en) Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '13337'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.13337/870; U; en) Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '13337'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.13337/19.916; U; en) Presto/2.5.25'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '13337'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.13265/870; U; ro) Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '13265'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.13221/886; U; en) Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '13221'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.13221/870; U; en) Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '13221'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.13057/870; U; ja) Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '13057'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2 19.42.55/19.892; U; en) Presto/2.5.25'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.18061/27.1407; U; en) Presto/2.8.119 Version/11.10'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '18061'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.1.15082/870; U; en) Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '1'
+    patch: '15082'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.1.15082/25.677; U; vi) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '1'
+    patch: '15082'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.1.15082/20.2489; U; en) Presto/2.5.25'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '1'
+    patch: '15082'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.1.14287/22.387; U; id) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '1'
+    patch: '14287'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.1.13907/21.529; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '1'
+    patch: '13907'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.1.13573/20.2485; U; zh) Presto/2.5.25'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '1'
+    patch: '13573'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.1.12965/19.892; U; en) Presto/2.5.25'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '1'
+    patch: '12965'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.1.11321/24.871; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '1'
+    patch: '11321'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.0.8462/22.414; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '0'
+    patch: '8462'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.0.8462/19.916; U; en) Presto/2.5.25'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '0'
+    patch: '8462'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.0.10247/19.916; U; en) Presto/2.5.25'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '0'
+    patch: '10247'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.0.10031/22.453; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '0'
+    patch: '10031'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.0/886; U; en) Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.0/870; U; id) Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.0/22.453; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.0/22.401; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.0/22.394; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.0 (X11; U; Linux i686 (x86_64); en-US; rv:1.8.1.11) Gecko/23.390; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.0 (Linux; U;'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.0 (iPad; U; CPU OS 3_2 like Mac OS X; en-us) AppleWebKit/23.411; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.0 (compatible; MSIE 5.0; UNIX) Opera 6.12 [en]/24.838; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.0 (BlackBerry; U; BlackBerry 9800; en) AppleWebKit/24.705; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Opera/9.60 (J2ME/MIDP; Opera Mini/4.0/490; U; en) Presto/2.2.0'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/3.1.10423/22.387; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '3'
+    minor: '1'
+    patch: '10423'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/1.6.0_13/22.478; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '1'
+    minor: '6'
+    patch: '0'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/1.6.0_13/19.916; U; en) Presto/2.5.25'
+    family: 'Opera Mini'
+    major: '1'
+    minor: '6'
+    patch: '0'
+
+  - user_agent_string: 'Opera/9.80 (Series 60; Opera Mini/1.0.30710/29.3594; U; en) Presto/2.8.119 Version/11.10'
+    family: 'Opera Mini'
+    major: '1'
+    minor: '0'
+    patch: '30710'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/1.0/886; U; en) Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '1'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/SymbianOS/22.478; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major:
+    minor:
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/Nokia2730c-1/22.478; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major:
+    minor:
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/Mozilla/23.334; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major:
+    minor:
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/(Windows; U; Windows NT 5.1; en-US) AppleWebKit/23.411; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major:
+    minor:
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini; U; zh) Presto/2.8.119 Version/11.10'
+    family: 'Opera Mini'
+    major:
+    minor:
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini; U; en) Presto/2.8.119 Version/11.1019 Version/11.10.10'
+    family: 'Opera Mini'
+    major:
+    minor:
+    patch:
+

--- a/uap-core/test_resources/pgts_browser_list.yaml
+++ b/uap-core/test_resources/pgts_browser_list.yaml
@@ -55,7 +55,7 @@ test_cases:
     patch:
 
   - user_agent_string: 'Alizee iPod 2005 (Beta; Mac OS X)'
-    family: 'Mobile Safari'
+    family: 'Mobile Safari UI/WKWebView'
     major:
     minor:
     patch:

--- a/uap-core/tests/test.js
+++ b/uap-core/tests/test.js
@@ -14,7 +14,8 @@ function msg(name, actual, expected) {
   return "Expected " + name + " to be " + JSON.stringify(expected) + " got " + JSON.stringify(actual) + " instead.";
 }
 
-['../test_resources/firefox_user_agent_strings.yaml', '../tests/test_ua.yaml', '../test_resources/pgts_browser_list.yaml'].forEach(function(fileName) {
+['../test_resources/firefox_user_agent_strings.yaml', '../tests/test_ua.yaml', '../test_resources/pgts_browser_list.yaml',
+  '../test_resources/opera_mini_user_agent_strings.yaml'].forEach(function(fileName) {
   var fixtures = readYAML(fileName).test_cases;
   suite(fileName, function() {
     fixtures.forEach(function(f) {

--- a/uap-core/tests/test_device.yaml
+++ b/uap-core/tests/test_device.yaml
@@ -77360,6 +77360,26 @@ test_cases:
     brand: 'XiaoMi'
     model: 'MI-ONE Plus'
 
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 4.4.4; zh-cn; HM 2A Build/KTU84Q) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/42.0.0.0 Mobile Safari/537.36 XiaoMi/MiuiBrowser/2.1.1'
+    family: 'XiaoMi HM 2A'
+    brand: 'XiaoMi'
+    model: 'HM 2A'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 4.4.4; zh-cn; HM NOTE 1LTE Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36 XiaoMi/MiuiBrowser/2.1.1'
+    family: 'XiaoMi HM NOTE 1LTE'
+    brand: 'XiaoMi'
+    model: 'HM NOTE 1LTE'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 5.0.2; zh-cn; MI NOTE Pro Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/42.0.0.0 Mobile Safari/537.36 XiaoMi/MiuiBrowser/2.1.1'
+    family: 'XiaoMi MI NOTE Pro'
+    brand: 'XiaoMi'
+    model: 'MI NOTE Pro'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 5.0.2; Redmi Note 2 Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/37.0.0.0 Mobile Safari/537.36 ssy={Android;ECalendar;V6.1.8;xiaomi;101181501;WIFI}'
+    family: 'XiaoMi Redmi Note 2'
+    brand: 'XiaoMi'
+    model: 'Redmi Note 2'
+
   - user_agent_string: 'Mozilla/5.0 (Linux; Android 4.1.1; XOLO A1000 Build/JRO03C) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19'
     family: 'Xolo A1000'
     brand: 'Xolo'
@@ -79744,3 +79764,19 @@ test_cases:
     family: 'Generic Smartphone'
     brand: 'Generic'
     model: 'Smartphone'
+
+  - user_agent_string: 'Roku/DVP-6.2 (096.02E06005A)'
+    family: 'Roku'
+    brand: 'Generic_Inettv'
+    model: 'Roku'
+
+  - user_agent_string: 'Roku/DVP-5.0 (025.00E08043A)'
+    family: 'Roku'
+    brand: 'Generic_Inettv'
+    model: 'Roku'
+
+  - user_agent_string: 'Roku/DVP-5.1 (025.01E01195A)'
+    family: 'Roku'
+    brand: 'Generic_Inettv'
+    model: 'Roku'
+

--- a/uap-core/tests/test_os.yaml
+++ b/uap-core/tests/test_os.yaml
@@ -2187,3 +2187,32 @@ test_cases:
     minor: '0'
     patch:
     patch_minor:
+
+  - user_agent_string: 'TestApp-tvOS/1.0-1'
+    family: 'tvOS'
+    major: '1'
+    minor: '0'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Roku/DVP-6.2 (096.02E06005A)'
+    family: 'Roku'
+    major: '6'
+    minor: '2'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Roku/DVP-5.0 (025.00E08043A)'
+    family: 'Roku'
+    major: '5'
+    minor: '0'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Roku/DVP-5.1 (025.01E01195A)'
+    family: 'Roku'
+    major: '5'
+    minor: '1'
+    patch:
+    patch_minor:
+

--- a/uap-core/tests/test_ua.yaml
+++ b/uap-core/tests/test_ua.yaml
@@ -146,9 +146,9 @@ test_cases:
 
   - user_agent_string: 'Mozilla/5.0 (BB10; Touch) AppleWebKit/537.3+ (KHTML, like Gecko) Version/10.0.9.388 Mobile Safari/537.3+'
     family: 'BlackBerry WebKit'
-    major:
-    minor:
-    patch:
+    major: '10'
+    minor: '0'
+    patch: '9'
 
   - user_agent_string: 'Mozilla/5.0 (PlayBook; U; RIM Tablet OS 1.0.0; en-US) AppleWebKit/534.8+ (KHTML, like Gecko) Version/0.0.1 Safari/534.8+'
     family: 'BlackBerry WebKit'
@@ -262,6 +262,12 @@ test_cases:
     family: 'GooglePlusBot'
     major:
     minor:
+    patch:
+
+  - user_agent_string: 'Twitterbot/1.0'
+    family: 'TwitterBot'
+    major: '1'
+    minor: '0'
     patch:
 
   - user_agent_string: 'Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.1.1pre) Gecko/20090717 Ubuntu/9.04 (jaunty) Shiretoko/3.5.1pre'
@@ -463,7 +469,7 @@ test_cases:
     patch: '2'
 
   - user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 7_1_2 like Mac OS X) AppleWebKit/537.51.2 (KHTML, like Gecko) Mobile/11D257'
-    family: 'Mobile Safari'
+    family: 'Mobile Safari UI/WKWebView'
     major: '7'
     minor: '1'
     patch: '2'
@@ -634,7 +640,7 @@ test_cases:
     family: 'Opera Mini'
     major: '5'
     minor: '1'
-    patch:
+    patch: '191'
 
   - user_agent_string: 'Opera/9.80 (Series 60; Opera Mini/6.24455/25.677; U; fr) Presto/2.5.25 Version/10.54'
     family: 'Opera Mini'
@@ -646,7 +652,31 @@ test_cases:
     family: 'Opera Mini'
     major: '7'
     minor: '0'
+    patch: '31437'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/9.80 (S60; SymbOS; Opera Mobi/23.348; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '9'
+    minor: '80'
     patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/9.80 (J2ME/22.478; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '9'
+    minor: '80'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/9 (Compatible; MSIE:9.0; iPhone; BlackBerry9700; AppleWebKit/24.746; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '9'
+    minor:
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (Android; Opera Mini/7.6.35766/35.5706; U; en) Presto/2.8.119 Version/11.10'
+    family: 'Opera Mini'
+    major: '7'
+    minor: '6'
+    patch: '35766'
 
   - user_agent_string: 'Opera/9.80 (S60; SymbOS; Opera Mobi/275; U; es-ES) Presto/2.4.13 Version/10.00'
     family: 'Opera Mobile'
@@ -1142,14 +1172,14 @@ test_cases:
     family: 'Opera Mini'
     major: '4'
     minor: '2'
-    patch:
+    patch: '14812'
     patch_minor:
 
   - user_agent_string: 'SAMSUNG-SGH-A897/A897UCJC1; Mozilla/5.0 (Profile/MIDP-2.0 Configuration/CLDC-1.1; Opera Mini/att/4.2.15304; U; fr-US) Opera 9.50'
     family: 'Opera Mini'
     major: '4'
     minor: '2'
-    patch:
+    patch: '15304'
     patch_minor:
 
   - user_agent_string: 'MQQBrowser/39 Mozilla/5.0 (iPhone 4S; CPU iPhone OS 6_0_1 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Mobile/10A523 Safari/7534.48.3'
@@ -3711,6 +3741,30 @@ test_cases:
     minor: '7'
     patch:
 
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 5.0.1; SAMSUNG GT-I9506-ORANGE Build/LRX22C) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/2.1 Chrome/34.0.1847.76 Mobile Safari/537.36'
+    family: 'Samsung Internet'
+    major: '2'
+    minor: '1'
+    patch:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 5.0.2; SAMSUNG SM-T800 Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/3.0 Chrome/38.0.2125.102 Safari/537.36'
+    family: 'Samsung Internet'
+    major: '3'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 5.1.1; SAMSUNG SM-G920F Build/LMY47X) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/3.2 Chrome/38.0.2125.102 Mobile Safari/537.36'
+    family: 'Samsung Internet'
+    major: '3'
+    minor: '2'
+    patch:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 5.0.2; SAMSUNG SM-T710 Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/3.5 Chrome/38.0.2125.102 Safari/537.36'
+    family: 'Samsung Internet'
+    major: '3'
+    minor: '5'
+    patch:
+
   - user_agent_string: 'ScSpider/0.2'
     family: 'ScSpider'
     major: '0'
@@ -6147,15 +6201,345 @@ test_cases:
     minor: '0'
     patch: '4'
 
-   - user_agent_string: 'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Spotify/1.0.3.101 Safari/537.36'
+  - user_agent_string: 'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Spotify/1.0.3.101 Safari/537.36'
     family: 'Spotify'
     major: '1'
     minor: '0'
     patch: '3'
 
-   - user_agent_string: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/537.36 (KHTML, like Gecko) Spotify/1.0.8.59 Safari/537.36'
+  - user_agent_string: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/537.36 (KHTML, like Gecko) Spotify/1.0.8.59 Safari/537.36'
     family: 'Spotify'
     major: '1'
     minor: '0'
     patch: '8'
+
+  - user_agent_string: 'Mozilla/5.0 (Android 5.0; Tablet; rv:41.0) Gecko/41.0 Firefox/41.0'
+    family: 'Firefox Mobile'
+    major: '41'
+    minor: '0'
+    patch:
+
+  - user_agent_string: '[FBAN/FB4A;FBAV/3.4;FBBV/258875;FBDM/{density=0.75,width=240,height=320};FBLC/tr_TR;FBCR/o2 - de;FBPN/com.facebook.katana;FBDV/LG-E400;FBSV/2.3.6;]'
+    family: 'Facebook'
+    major: '3'
+    minor: '4'
+    patch:
+
+  - user_agent_string: '[FBAN/FB4A;FBAV/2.3;FBBV/149649;FBDM/{density=1.5,width=480,height=800};FBLC/es_ES;FBCR/;FBPN/com.facebook.katana;FBDV/LG-P920;FBSV/2.2.2;]'
+    family: 'Facebook'
+    major: '2'
+    minor: '3'
+    patch:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 2.3.4; en-us; SCH-R720 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1 [FBAN/FB4A;FBAV/1.8.1;FBPN/com.facebook.katana;FBDV/SCH-R720;FBSV/2.3.4;FBDM/{density=1.0,width=320,height='
+    family: 'Facebook'
+    major: '1'
+    minor: '8'
+    patch: '1'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 4.2.2; de-de; 706_v92_jbla_fhd Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 [FB_IAB/FB4A;FBAV/24.0.0.30.15;]'
+    family: 'Facebook'
+    major: '24'
+    minor: '0'
+    patch: '0'
+
+  - user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 6_1_3 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Mobile/10B329 [FBAN/FBIOS;FBAV/6.5.1;FBBV/377040;FBDV/iPhone4,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/6.1.3;FBSS/2; FBCR/Telekom.de;FBID/phone;FBLC/de_DE;'
+    family: 'Facebook'
+    major: '6'
+    minor: '5'
+    patch: '1'
+
+  - user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 6_1_3 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Mobile/10B329 [FBAN/FBIOS;FBAV/6.2;FBBV/228172;FBDV/iPhone5,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/6.1.3;FBSS/2; FBCR/o2-de;FBID/phone;FBLC/pt_BR;FBOP/1]'
+    family: 'Facebook'
+    major: '6'
+    minor: '2'
+    patch:
+
+  - user_agent_string: 'Mozilla/5.0 (iPad; CPU OS 5_0 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Mobile/9A334 [FBAN/FBIOS;FBAV/6.5.1;FBBV/377040;FBDV/iPad2,1;FBMD/iPad;FBSN/iPhone OS;FBSV/5.0;FBSS/1; FBCR/;FBID/tablet;FBLC/de_DE;FBOP/1]'
+    family: 'Facebook'
+    major: '6'
+    minor: '5'
+    patch: '1'
+
+  - user_agent_string: 'Mozilla/5.0 (iPad; U; CPU iPhone OS 4_3_2 like Mac OS X; de_DE) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPad1,1;FBMD/iPad;FBSN/iPhone OS;FBSV/4.3.2;FBSS/1; FBCR/;FBID/tablet;FBLC/de_DE;FBSF/1.0]'
+    family: 'Facebook'
+    major: '4'
+    minor: '0'
+    patch: '2'
+
+  - user_agent_string: 'Mozilla/5.0 (iPad; U; CPU iPhone OS 4_3_5 like Mac OS X; de_DE) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.3;FBBV/4030.0;FBDV/iPad2,2;FBMD/iPad;FBSN/iPhone OS;FBSV/4.3.5;FBSS/1; FBCR/Telekom.de;FBID/tablet;FBLC/de_DE;FBS'
+    family: 'Facebook'
+    major: '4'
+    minor: '0'
+    patch: '3'
+
+  - user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 5_1_1 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Mobile/9B206 [FBAN/FBIOS;FBAV/6.1;FBBV/201075;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/5.1.1;FBSS/2; FBCR/Vodafone.de;FBID/phone;FBLC/en_US;FBOP/1]'
+    family: 'Facebook'
+    major: '6'
+    minor: '1'
+    patch:
+
+  - user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 8_2 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Mobile/12D508 [FBAN/GroupsForiOS;FBAV/9.0;FBBV/7752968;FBDV/iPhone7,2;FBMD/iPhone;FBSN/iPhone OS;FBSV/8.2;FBSS/2; FBCR/Telekom.de;FBID/phone;FBLC/de_'
+    family: 'Facebook'
+    major: '9'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_1 like Mac OS X; fr_FR) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0;FBBV/4000.0;FBDV/iPhone1,2;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.1;FBSS/1; FBCR/Carrier;FBID/phone;FBLC/fr_FR;FBSF/1.'
+    family: 'Facebook'
+    major: '4'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Dalvik/1.2.0 (Linux; U; Android 2.2.2; HTC Desire Build/FRG83G) [FBAN/Orca-Android;FBAV/2.6.1-release;FBLC/de_DE;FBBV/288543;FBCR/o2 - de;FBMF/HTC;FBBD/htc_wwe;FBDV/HTC Desire;FBSV/2.2.2]'
+    family: 'Facebook'
+    major: '2'
+    minor: '6'
+    patch: '1'
+
+  - user_agent_string: '[FBAN/FB4A;FBAV/3.6;FBBV/330148;FBDM/{density=0.75,width=240,height=320};FBLC/de_DE;FBCR/o2 - de;FBPN/com.facebook.katana;FBDV/GT-S5570;FBSV/2.2.1;FBCA/armeabi:unknown;]'
+    family: 'Facebook'
+    major: '3'
+    minor: '6'
+    patch:
+
+  - user_agent_string: '[FBAN/PAAA;FBAV/1.7;FBDM/{density=2.0,width=720,height=1280};FBLC/es_ES;FB_FW/2;FBSN/Android;FBCR/FONIC;FBDV/GT-I9300;FBSV/4.1.2;]'
+    family: 'Facebook'
+    major: '1'
+    minor: '7'
+    patch:
+
+  - user_agent_string: '[FBAN/PAAA;FBAV/1.9;FBDM/{density=2.0,width=720,height=1280};FBLC/de_DE;FB_FW/2;FBSN/Android;FBCR/o2 - de;FBDV/GT-I9300;FBSV/4.3;]'
+    family: 'Facebook'
+    major: '1'
+    minor: '9'
+    patch:
+
+  - user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 6_1_4 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Mobile/10B350 [Pinterest/iOS]'
+    family: 'Pinterest'
+    major:
+    minor:
+    patch:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 4.4.2; A3-A11 Build/KOT49H) AppleWebKit/537.36 (KHTML like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36 [Pinterest/Android]'
+    family: 'Pinterest'
+    major:
+    minor:
+    patch:
+
+  - user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 6_0_1 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Mobile/10A525 [Pinterest/iOS]'
+    family: 'Pinterest'
+    major:
+    minor:
+    patch:
+
+  - user_agent_string: 'Pinterest for Android Tablet/1.8.4 (SGP321; 4.3)'
+    family: 'Pinterest'
+    major: '1'
+    minor: '8'
+    patch: '4'
+
+  - user_agent_string: 'Pinterest for Android Tablet/4.3.1 (A7600-H; 4.4.2)'
+    family: 'Pinterest'
+    major: '4'
+    minor: '3'
+    patch: '1'
+
+  - user_agent_string: 'Pinterest for Android/1.1.1 (endeavoru; 4.1.1)'
+    family: 'Pinterest'
+    major: '1'
+    minor: '1'
+    patch: '1'
+
+  - user_agent_string: 'Pinterest for Android/3.6.2 (klte; 4.4.2)'
+    family: 'Pinterest'
+    major: '3'
+    minor: '6'
+    patch: '2'
+
+  - user_agent_string: 'Pinterest/0.1'
+    family: 'Pinterest'
+    major: '0'
+    minor: '1'
+    patch:
+
+  - user_agent_string: 'Pinterest/0.2 (+http://www.pinterest.com/)'
+    family: 'Pinterest'
+    major: '0'
+    minor: '2'
+    patch:
+
+  - user_agent_string: 'Pinterest/3.2 CFNetwork/672.0.8 Darwin/14.0.0'
+    family: 'CFNetwork'
+    major: '672'
+    minor: '0'
+    patch: '8'
+
+  - user_agent_string: 'Pinterest/3.3.3 CFNetwork/609.1.4 Darwin/13.0.0'
+    family: 'CFNetwork'
+    major: '609'
+    minor: '1'
+    patch: '4'
+
+  - user_agent_string: 'Pinterest/3356 CFNetwork/711.0.6 Darwin/14.0.0'
+    family: 'CFNetwork'
+    major: '711'
+    minor: '0'
+    patch: '6'
+
+  - user_agent_string: 'Pinterest/4.1.3 CFNetwork/672.1.14 Darwin/14.0.0'
+    family: 'CFNetwork'
+    major: '672'
+    minor: '1'
+    patch: '14'
+
+  - user_agent_string: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/538.1 (KHTML, like Gecko) qutebrowser/0.2.1 Safari/538.1'
+    family: 'qutebrowser'
+    major: '0'
+    minor: '2'
+    patch: '1'
+
+  - user_agent_string: 'Mozilla/5.0 (iPad; U; CPU OS 4_3_2 like Mac OS X; en-us) AppleWebKit/533.17.9 (KHTML, like Gecko) Mobile'
+    family: 'Mobile Safari UI/WKWebView'
+    major: '4'
+    minor: '3'
+    patch: '2'
+
+  - user_agent_string: 'Mozilla/5.0 (iPad; U; CPU OS 4_3_2 like Mac OS X; en-us) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8H7 Safari'
+    family: 'Mobile Safari'
+    major: '5'
+    minor: '0'
+    patch: '2'
+
+  - user_agent_string: 'Mozilla/5.0 (Macintosh; Intel Mac OS X) AppleWebKit/538.1 (KHTML, like Gecko) QupZilla/1.6.3 Safari/538.1'
+    family: 'QupZilla'
+    major: '1'
+    minor: '6'
+    patch: '3'
+
+  - user_agent_string: 'Mozilla/5.0 (OS/2 Warp 4.5) AppleWebKit/537.21 (KHTML, like Gecko) QupZilla/1.6.4 Safari/537.21'
+    family: 'QupZilla'
+    major: '1'
+    minor: '6'
+    patch: '4'
+
+  - user_agent_string: 'Mozilla/5.0 (Unknown; UNIX BSD/SYSV system) AppleWebKit/534.34 (KHTML, like Gecko) QupZilla/1.7.0 Safari/534.34'
+    family: 'QupZilla'
+    major: '1'
+    minor: '7'
+    patch: '0'
+
+  - user_agent_string: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.21 (KHTML, like Gecko) QupZilla/1.6.1 Safari/537.21'
+    family: 'QupZilla'
+    major: '1'
+    minor: '6'
+    patch: '1'
+
+  - user_agent_string: 'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/538.1 (KHTML, like Gecko) Otter/0.9.03 beta 3 Safari/538.1'
+    family: 'Otter'
+    major: '0'
+    minor: '9'
+    patch: '03'
+
+  - user_agent_string: 'Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/538.1 (KHTML, like Gecko) Otter/0.9.04'
+    family: 'Otter'
+    major: '0'
+    minor: '9'
+    patch: '04'
+
+  - user_agent_string: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.21 (KHTML, like Gecko) Otter/0.9.04-dev'
+    family: 'Otter'
+    major: '0'
+    minor: '9'
+    patch: '04'
+
+  - user_agent_string: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/538.1 (KHTML, like Gecko) Otter/0.3.01-dev Safari/538.1'
+    family: 'Otter'
+    major: '0'
+    minor: '3'
+    patch: '01'
+
+  - user_agent_string: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/538.1 (KHTML, like Gecko) Otter/0.9.03 beta 3 Safari/538.1'
+    family: 'Otter'
+    major: '0'
+    minor: '9'
+    patch: '03'
+
+  - user_agent_string: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/538.1 (KHTML, like Gecko) Otter/0.9.05'
+    family: 'Otter'
+    major: '0'
+    minor: '9'
+    patch: '05'
+
+  - user_agent_string: 'Mozilla/5.0 (Windows Phone 10.0; Android 4.2.1; NOKIA; Lumia 930) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.71 Mobile Safari/537.36 Edge/12.0'
+    family: 'Edge Mobile'
+    major: '12'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_2) AppleWebKit/537.36 (KHTML, like Gecko) brave/0.7.11 Chrome/47.0.2526.110 Brave/0.36.5 Safari/537.36'
+    family: 'Brave'
+    major: '0'
+    minor: '7'
+    patch: '11'
+
+  - user_agent_string: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) brave/0.7.12 Chrome/47.0.2526.110 Brave/0.36.7 Safari/537.36 '
+    family: 'Brave'
+    major: '0'
+    minor: '7'
+    patch: '12'
+
+  - user_agent_string: 'Mozilla/5.0 (Windows NT 6.3; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) brave/0.7.10 Chrome/47.0.2526.110 Brave/0.36.5 Safari/537.36'
+    family: 'Brave'
+    major: '0'
+    minor: '7'
+    patch: '10'
+
+  - user_agent_string: 'Roku/DVP-6.2 (096.02E06005A)'
+    family: 'Roku'
+    major: '6'
+    minor: '2'
+    patch:
+
+  - user_agent_string: 'Roku/DVP-5.0 (025.00E08043A)'
+    family: 'Roku'
+    major: '5'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Roku/DVP-5.1 (025.01E01195A)'
+    family: 'Roku'
+    major: '5'
+    minor: '1'
+    patch:
+
+  - user_agent_string: 'Microsoft Office/12.0 (Windows NT 6.1; Microsoft Office Outlook 12.0.6739; Pro)'
+    family: 'Outlook'
+    major: '2007'
+    minor:
+    patch:
+
+  - user_agent_string: 'Microsoft Office/14.0 (Windows NT 6.1; Microsoft Outlook 14.0.5128; Pro)'
+    family: 'Outlook'
+    major: '2010'
+    minor:
+    patch:
+
+  - user_agent_string: 'Microsoft Office/16.0 (Microsoft Outlook Mail 16.0.6525; Pro)'
+    family: 'Outlook'
+    major: '2016'
+    minor:
+    patch:
+
+  - user_agent_string: 'Microsoft Office/16.0 (Windows NT 10.0; Microsoft Outlook 16.0.6326; Pro)'
+    family: 'Outlook'
+    major: '2016'
+    minor:
+    patch:
+
+  - user_agent_string: 'Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 10.0; WOW64; Trident/8.0; .NET4.0C; .NET4.0E; .NET CLR 2.0.50727; .NET CLR 3.0.30729; .NET CLR 3.5.30729; Microsoft Outlook 16.0.6366; ms-office; MSOffice 16)'
+    family: 'Outlook'
+    major: '2016'
+    minor:
+    patch:
 


### PR DESCRIPTION
This updates uap-core to the latest master as of 4/25/16, and adds instructions for doing so to `contributing.md`.