### PR TITLE
Loading parser definitions with standard yaml tags

### DIFF
--- a/uaparser/device.go
+++ b/uaparser/device.go
@@ -1,9 +1,6 @@
 package uaparser
 
-import (
-	"regexp"
-	"strings"
-)
+import "strings"
 
 type Device struct {
 	Family string
@@ -11,38 +8,29 @@ type Device struct {
 	Model  string
 }
 
-type DevicePattern struct {
-	Regexp            *regexp.Regexp
-	Regex             string
-	RegexFlag         string
-	BrandReplacement  string
-	DeviceReplacement string
-	ModelReplacement  string
-}
-
-func (dvcPattern *DevicePattern) Match(line string, dvc *Device) {
-	matches := dvcPattern.Regexp.FindStringSubmatch(line)
+func (parser *deviceParser) Match(line string, dvc *Device) {
+	matches := parser.Reg.FindStringSubmatch(line)
 	if len(matches) == 0 {
 		return
 	}
-	groupCount := dvcPattern.Regexp.NumSubexp()
+	groupCount := parser.Reg.NumSubexp()
 
-	if len(dvcPattern.DeviceReplacement) > 0 {
-		dvc.Family = allMatchesReplacement(dvcPattern.DeviceReplacement, matches)
+	if len(parser.DeviceReplacement) > 0 {
+		dvc.Family = allMatchesReplacement(parser.DeviceReplacement, matches)
 	} else if groupCount >= 1 {
 		dvc.Family = matches[1]
 	}
 	dvc.Family = strings.TrimSpace(dvc.Family)
-	if len(dvcPattern.BrandReplacement) > 0 {
-		if strings.Contains(dvcPattern.BrandReplacement, "$") {
-			dvc.Brand = allMatchesReplacement(dvcPattern.BrandReplacement, matches)
+	if len(parser.BrandReplacement) > 0 {
+		if strings.Contains(parser.BrandReplacement, "$") {
+			dvc.Brand = allMatchesReplacement(parser.BrandReplacement, matches)
 		} else {
-			dvc.Brand = dvcPattern.BrandReplacement
+			dvc.Brand = parser.BrandReplacement
 		}
 	}
 	dvc.Brand = strings.TrimSpace(dvc.Brand)
-	if len(dvcPattern.ModelReplacement) > 0 {
-		dvc.Model = allMatchesReplacement(dvcPattern.ModelReplacement, matches)
+	if len(parser.ModelReplacement) > 0 {
+		dvc.Model = allMatchesReplacement(parser.ModelReplacement, matches)
 	} else if groupCount >= 1 {
 		dvc.Model = matches[1]
 	}

--- a/uaparser/os.go
+++ b/uaparser/os.go
@@ -1,9 +1,5 @@
 package uaparser
 
-import (
-	"regexp"
-)
-
 type Os struct {
 	Family     string
 	Major      string
@@ -12,40 +8,31 @@ type Os struct {
 	PatchMinor string
 }
 
-type OsPattern struct {
-	Regexp          *regexp.Regexp
-	Regex           string
-	OsReplacement   string
-	OsV1Replacement string
-	OsV2Replacement string
-	OsV3Replacement string
-}
-
-func (osPattern *OsPattern) Match(line string, os *Os) {
-	matches := osPattern.Regexp.FindStringSubmatch(line)
+func (parser *osParser) Match(line string, os *Os) {
+	matches := parser.Reg.FindStringSubmatch(line)
 	if len(matches) > 0 {
-		groupCount := osPattern.Regexp.NumSubexp()
+		groupCount := parser.Reg.NumSubexp()
 
-		if len(osPattern.OsReplacement) > 0 {
-			os.Family = singleMatchReplacement(osPattern.OsReplacement, matches, 1)
+		if len(parser.OSReplacement) > 0 {
+			os.Family = singleMatchReplacement(parser.OSReplacement, matches, 1)
 		} else if groupCount >= 1 {
 			os.Family = matches[1]
 		}
 
-		if len(osPattern.OsV1Replacement) > 0 {
-			os.Major = singleMatchReplacement(osPattern.OsV1Replacement, matches, 2)
+		if len(parser.V1Replacement) > 0 {
+			os.Major = singleMatchReplacement(parser.V1Replacement, matches, 2)
 		} else if groupCount >= 2 {
 			os.Major = matches[2]
 		}
 
-		if len(osPattern.OsV2Replacement) > 0 {
-			os.Minor = singleMatchReplacement(osPattern.OsV2Replacement, matches, 3)
+		if len(parser.V2Replacement) > 0 {
+			os.Minor = singleMatchReplacement(parser.V2Replacement, matches, 3)
 		} else if groupCount >= 3 {
 			os.Minor = matches[3]
 		}
 
-		if len(osPattern.OsV3Replacement) > 0 {
-			os.Patch = singleMatchReplacement(osPattern.OsV3Replacement, matches, 4)
+		if len(parser.V3Replacement) > 0 {
+			os.Patch = singleMatchReplacement(parser.V3Replacement, matches, 4)
 		} else if groupCount >= 4 {
 			os.Patch = matches[4]
 		}

--- a/uaparser/os_test.go
+++ b/uaparser/os_test.go
@@ -6,11 +6,11 @@ import (
 )
 
 var osDefaultRegexFile string = uapCoreRoot + "/regexes.yaml"
-var osParser *Parser = nil
+var osTestParser *Parser = nil
 
 func osInitParser(regexFile string) {
-	if osParser == nil {
-		osParser, _ = New(regexFile)
+	if osTestParser == nil {
+		osTestParser, _ = New(regexFile)
 	}
 }
 

--- a/uaparser/user_agent.go
+++ b/uaparser/user_agent.go
@@ -1,9 +1,5 @@
 package uaparser
 
-import (
-	"regexp"
-)
-
 type UserAgent struct {
 	Family string
 	Major  string
@@ -11,34 +7,25 @@ type UserAgent struct {
 	Patch  string
 }
 
-type UserAgentPattern struct {
-	Regexp            *regexp.Regexp
-	Regex             string
-	RegexFlag         string
-	FamilyReplacement string
-	V1Replacement     string
-	V2Replacement     string
-}
-
-func (uaPattern *UserAgentPattern) Match(line string, ua *UserAgent) {
-	matches := uaPattern.Regexp.FindStringSubmatch(line)
+func (parser *uaParser) Match(line string, ua *UserAgent) {
+	matches := parser.Reg.FindStringSubmatch(line)
 	if len(matches) > 0 {
-		groupCount := uaPattern.Regexp.NumSubexp()
+		groupCount := parser.Reg.NumSubexp()
 
-		if len(uaPattern.FamilyReplacement) > 0 {
-			ua.Family = singleMatchReplacement(uaPattern.FamilyReplacement, matches, 1)
+		if len(parser.FamilyReplacement) > 0 {
+			ua.Family = singleMatchReplacement(parser.FamilyReplacement, matches, 1)
 		} else if groupCount >= 1 {
 			ua.Family = matches[1]
 		}
 
-		if len(uaPattern.V1Replacement) > 0 {
-			ua.Major = singleMatchReplacement(uaPattern.V1Replacement, matches, 2)
+		if len(parser.V1Replacement) > 0 {
+			ua.Major = singleMatchReplacement(parser.V1Replacement, matches, 2)
 		} else if groupCount >= 2 {
 			ua.Major = matches[2]
 		}
 
-		if len(uaPattern.V2Replacement) > 0 {
-			ua.Minor = singleMatchReplacement(uaPattern.V2Replacement, matches, 3)
+		if len(parser.V2Replacement) > 0 {
+			ua.Minor = singleMatchReplacement(parser.V2Replacement, matches, 3)
 		} else if groupCount >= 3 {
 			ua.Minor = matches[3]
 			if groupCount >= 4 {

--- a/uaparser/user_agent_test.go
+++ b/uaparser/user_agent_test.go
@@ -6,11 +6,11 @@ import (
 )
 
 var uaDefaultRegexFile string = uapCoreRoot + "/regexes.yaml"
-var uaParser *Parser = nil
+var uaTestParser *Parser = nil
 
 func uaInitParser(regexFile string) {
-	if uaParser == nil {
-		uaParser, _ = New(regexFile)
+	if uaTestParser == nil {
+		uaTestParser, _ = New(regexFile)
 	}
 }
 
@@ -18,7 +18,7 @@ func uaTest(c *Client, test map[string]string) bool {
 	ua := c.UserAgent
 	if ua.Family != test["family"] || ua.Major != test["major"] ||
 		ua.Minor != test["minor"] || ua.Patch != test["patch"] {
-		fmt.Printf("Expected: %v\nActual: %v\n", test, ua)
+		fmt.Printf("Expected: %q\vActual: %#v\n", test, ua)
 		return false
 	}
 	return true


### PR DESCRIPTION
Only loading has been changed. No change in parsing logic. All test still pass.

* Simplify and standardize loading & parsing of `regexes.yaml`
* Remove unneeded extra custom code
* Support multiple flags and for all parsers

Note: Too bad cannot yet use the `yaml.UnmarshalYAML` (until
support of embedded struct pointer)