### PR TITLE
Re-implement NewFromBytes

### DIFF
--- a/uaparser/parser.go
+++ b/uaparser/parser.go
@@ -84,7 +84,10 @@ func New(regexFile string) (*Parser, error) {
 	if nil != err {
 		return nil, err
 	}
+	return NewFromBytes(data)
+}
 
+func NewFromBytes(data []byte) (*Parser, error) {
 	var definitions RegexesDefinitions
 	if err := yaml.Unmarshal(data, &definitions); err != nil {
 		return nil, err


### PR DESCRIPTION
The most recent PR removed the NewFromBytes function, which was very useful. This re-implements it.