### PR TITLE
Faster by concurrently parsing the OS, UA & Device

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,13 @@ This is the Go implementation of the [ua-parser](https://github.com/tobie/ua-par
     $ cd uaparser
     $ go test -v -cover
 
+When adding new feature you can check for data race with `go test -race`, although this command
+will take more than 2 minutes to execute since the `-race` flag adds some instrumentation on all regex matches
+
+So a quicker way to test data race on the main `*parser.Parse` method can be:
+
+    $ go test -race -run=Concurrency  # filter to execute `TestGenericParseMethodConcurrency` only
+
 ## Benching
 
 If needed, you can run benchmark on your latest feature to be compared (using `benchcmp`) against the current performance

--- a/uaparser/parser.go
+++ b/uaparser/parser.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"regexp"
+	"sync"
 
 	"gopkg.in/yaml.v2"
 )
@@ -133,9 +134,29 @@ func NewFromBytes(data []byte) (*Parser, error) {
 
 func (parser *Parser) Parse(line string) *Client {
 	cli := new(Client)
-	cli.UserAgent = parser.ParseUserAgent(line)
-	cli.Os = parser.ParseOs(line)
-	cli.Device = parser.ParseDevice(line)
+
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		cli.UserAgent = parser.ParseUserAgent(line)
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		cli.Os = parser.ParseOs(line)
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		cli.Device = parser.ParseDevice(line)
+	}()
+
+	wg.Wait()
+
 	return cli
 }
 

--- a/uaparser/parsing_test.go
+++ b/uaparser/parsing_test.go
@@ -82,6 +82,27 @@ func TestDeviceParsing(t *testing.T) {
 	}
 }
 
+func TestGenericParseMethodConcurrency(t *testing.T) { // go test -race -run=Concurrency
+	var YAMLTestCases struct {
+		Cases []struct {
+			Input    string `yaml:"user_agent_string"`
+			Expected Os     `yaml:",inline"`
+		} `yaml:"test_cases"`
+	}
+
+	for _, filepath := range []string{"../uap-core/tests/test_os.yaml"} {
+		unmarshalResourceTestFile(filepath, &YAMLTestCases)
+
+		for _, c := range YAMLTestCases.Cases {
+			actual := testParser.Parse(c.Input).Os
+			if got, want := *actual, c.Expected; got != want {
+				t.Fatalf("got %#v\n want %#v\n", got, want)
+			}
+		}
+	}
+}
+
+
 func unmarshalResourceTestFile(filepath string, v interface{}) {
 	file, err := ioutil.ReadFile(filepath)
 	if nil != err {


### PR DESCRIPTION
* Gain of 33%
* `uap-go` is often used on server side to parse agents from incoming http requests i.e. high volume. Making it a bit faster while preserving Goroutine safety is therefore useful.
```
benchmark             old ns/op     new ns/op     delta
BenchmarkParser-8     27243975      18124922      -33.47%
```