### PR TITLE
Add support for Go modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/ua-parser/uap-go
+
+require gopkg.in/yaml.v2 v2.2.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.1 h1:mUhvW9EsL+naU5Q3cakzfE91YhliOondGd6ZrsDBHQE=
+gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/test.go
+++ b/test.go
@@ -3,7 +3,7 @@ package main
 import (
 	"bufio"
 	"fmt"
-	"github.com/streamrail/uap-go/uaparser"
+	"github.com/ua-parser/uap-go/uaparser"
 	"os"
 	"strconv"
 	"sync"

--- a/test.go
+++ b/test.go
@@ -12,7 +12,7 @@ import (
 
 func main() {
 	if len(os.Args) < 3 {
-		fmt.Println("Usage: %s [old|new|both] [concurrency level]\n", os.Args[0])
+		fmt.Printf("Usage: %s [old|new|both] [concurrency level]\n", os.Args[0])
 		return
 	}
 	var wg sync.WaitGroup


### PR DESCRIPTION
cc @elsigh 

This PR adds support for Go modules. I also fixed `test.go` which was importing uaparser from `github.com/streamrail/uap-go/uaparser` and replaced it with `github.com/ua-parser/uap-go/uaparser`

There was also a Go vet error that was failing on Go 1.10 and Go  1.11. There's a separate commit in the PR that fixes this.