### PR TITLE
Expose the Yaml definition to consumers

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -7,4 +7,4 @@ yaml=`cat uap-core/regexes.yaml | sed '/\s*#/d' | sed '/^\s*$/d'`
 
 # Build and format a Go file including our sources:
 echo "package uaparser
-var definitionYaml = []byte(\`$yaml\`)" | gofmt > uaparser/yaml.go
+var DefinitionYaml = []byte(\`$yaml\`)" | gofmt > uaparser/yaml.go

--- a/uaparser/parser.go
+++ b/uaparser/parser.go
@@ -197,7 +197,7 @@ func New(regexFile string) (*Parser, error) {
 }
 
 func NewFromSaved() *Parser {
-	parser, err := NewFromBytes(definitionYaml)
+	parser, err := NewFromBytes(DefinitionYaml)
 	if err != nil {
 		// if the YAML is malformed, it's a programmatic error inside what
 		// we've statically-compiled in our binary. Panic!

--- a/uaparser/yaml.go
+++ b/uaparser/yaml.go
@@ -1,6 +1,6 @@
 package uaparser
 
-var definitionYaml = []byte(`user_agent_parsers:
+var DefinitionYaml = []byte(`user_agent_parsers:
   - regex: '(ESPN)[%20| ]+Radio/(\d+)\.(\d+)\.(\d+) CFNetwork'
   - regex: '(Antenna)/(\d+) CFNetwork'
     family_replacement: 'AntennaPod'


### PR DESCRIPTION
I don't think it's currently possible to use the default list of regex and add some custom regex. Right now, we need to copy the regex list in our project and add our custom regex to this copied list. I propose to expose the list so we can merge our custom regex with the default list.

Note: I'm really new to go. In fact, it's the first time I'm working on a go project. Suggestions are welcome 😃

cc @elsigh 
