### PR TITLE
Add cache to improve performance 300x

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,6 @@
 module github.com/ua-parser/uap-go
 
-require gopkg.in/yaml.v2 v2.2.1
+require (
+	github.com/hashicorp/golang-lru v0.5.4
+	gopkg.in/yaml.v2 v2.2.1
+)

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
+github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.1 h1:mUhvW9EsL+naU5Q3cakzfE91YhliOondGd6ZrsDBHQE=

--- a/uaparser/cache.go
+++ b/uaparser/cache.go
@@ -1,0 +1,36 @@
+package uaparser
+
+import lru "github.com/hashicorp/golang-lru"
+
+// cache caches user-agent properties.
+// Without the cache, the parser performs hundreds of expensive regex operations,
+// taking 10+ ms. This can lead to significant performance degradation when UA parsing is
+// done on a per-request basis.
+type cache struct {
+	device    *lru.ARCCache
+	os        *lru.ARCCache
+	userAgent *lru.ARCCache
+}
+
+func newCache() *cache {
+	var (
+		c   cache
+		err error
+	)
+	const cacheSize = 1024
+	// NewARC only fails when cacheSize <= 0.
+	// Also, returning an error up the stack would break the API.
+	c.device, err = lru.NewARC(cacheSize)
+	if err != nil {
+		panic(err)
+	}
+	c.os, err = lru.NewARC(cacheSize)
+	if err != nil {
+		panic(err)
+	}
+	c.userAgent, err = lru.NewARC(cacheSize)
+	if err != nil {
+		panic(err)
+	}
+	return &c
+}


### PR DESCRIPTION
The caching is a bit janky and atypical of a parsing library, but I think the performance improvements justify it.

```
benchmark                         old ns/op     new ns/op     delta
BenchmarkParser-32                13418192      38386         -99.71%
BenchmarkParserWithOptions-32     10629612      24925         -99.77%
```