### PR TITLE
Parse() performance optimization

### DIFF
--- a/uaparser/parser.go
+++ b/uaparser/parser.go
@@ -231,35 +231,21 @@ func NewFromBytes(data []byte) (*Parser, error) {
 
 func (parser *Parser) Parse(line string) *Client {
 	cli := new(Client)
-	var wg sync.WaitGroup
 	if EUserAgentLookUpMode&parser.Mode == EUserAgentLookUpMode {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			parser.RLock()
-			cli.UserAgent = parser.ParseUserAgent(line)
-			parser.RUnlock()
-		}()
+		parser.RLock()
+		cli.UserAgent = parser.ParseUserAgent(line)
+		parser.RUnlock()
 	}
 	if EOsLookUpMode&parser.Mode == EOsLookUpMode {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			parser.RLock()
-			cli.Os = parser.ParseOs(line)
-			parser.RUnlock()
-		}()
+		parser.RLock()
+		cli.Os = parser.ParseOs(line)
+		parser.RUnlock()
 	}
 	if EDeviceLookUpMode&parser.Mode == EDeviceLookUpMode {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			parser.RLock()
-			cli.Device = parser.ParseDevice(line)
-			parser.RUnlock()
-		}()
+		parser.RLock()
+		cli.Device = parser.ParseDevice(line)
+		parser.RUnlock()
 	}
-	wg.Wait()
 	if parser.UseSort == true {
 		checkAndSort(parser)
 	}

--- a/uaparser/parser.go
+++ b/uaparser/parser.go
@@ -338,33 +338,35 @@ func (parser *Parser) ParseDevice(line string) *Device {
 }
 
 func checkAndSort(parser *Parser) {
-	parser.Lock()
 	if atomic.LoadUint64(&parser.UserAgentMisses) >= missesTreshold {
 		if parser.debugMode {
 			fmt.Printf("%s\tSorting UserAgents slice\n", time.Now())
 		}
+		parser.Lock()
 		parser.UserAgentMisses = 0
 		sort.Sort(UserAgentSorter(parser.UA))
+		parser.Unlock()
 	}
-	parser.Unlock()
-	parser.Lock()
+
 	if atomic.LoadUint64(&parser.OsMisses) >= missesTreshold {
 		if parser.debugMode {
 			fmt.Printf("%s\tSorting OS slice\n", time.Now())
 		}
+		parser.Lock()
 		parser.OsMisses = 0
 		sort.Sort(OsSorter(parser.OS))
+		parser.Unlock()
 	}
-	parser.Unlock()
-	parser.Lock()
+
 	if atomic.LoadUint64(&parser.DeviceMisses) >= missesTreshold {
 		if parser.debugMode {
 			fmt.Printf("%s\tSorting Device slice\n", time.Now())
 		}
+		parser.Lock()
 		parser.DeviceMisses = 0
 		sort.Sort(DeviceSorter(parser.Device))
+		parser.Unlock()
 	}
-	parser.Unlock()
 }
 
 func compileRegex(flags, expr string) *regexp.Regexp {


### PR DESCRIPTION
```sh
$ benchstat old.txt new.txt 
name                  old time/op    new time/op    delta
Parser-12               25.7µs ± 0%     4.5µs ± 1%  -82.58%  (p=0.000 n=10+10)
ParserWithOptions-12    18.9µs ± 1%     3.2µs ± 1%  -83.34%  (p=0.000 n=10+10)

name                  old alloc/op   new alloc/op   delta
Parser-12               3.02kB ± 0%    0.94kB ± 0%  -68.97%  (p=0.000 n=10+10)
ParserWithOptions-12    2.18kB ± 0%    0.73kB ± 0%  -66.67%  (p=0.000 n=10+10)

name                  old allocs/op  new allocs/op  delta
Parser-12                  104 ± 0%        52 ± 0%  -50.00%  (p=0.000 n=10+10)
ParserWithOptions-12      78.0 ± 0%      39.0 ± 0%  -50.00%  (p=0.000 n=10+10)
```

<details>

<summary>old.txt</summary>

```
goos: darwin
goarch: amd64
pkg: github.com/ua-parser/uap-go/uaparser
cpu: Intel(R) Core(TM) i5-10600 CPU @ 3.30GHz
BenchmarkParser-12               	   46122	     25753 ns/op	    3016 B/op	     104 allocs/op
BenchmarkParser-12               	   46458	     25668 ns/op	    3016 B/op	     104 allocs/op
BenchmarkParser-12               	   46448	     25628 ns/op	    3016 B/op	     104 allocs/op
BenchmarkParser-12               	   45872	     25721 ns/op	    3016 B/op	     104 allocs/op
BenchmarkParser-12               	   45996	     25727 ns/op	    3016 B/op	     104 allocs/op
BenchmarkParser-12               	   46208	     25595 ns/op	    3016 B/op	     104 allocs/op
BenchmarkParser-12               	   45688	     25792 ns/op	    3016 B/op	     104 allocs/op
BenchmarkParser-12               	   46124	     25639 ns/op	    3016 B/op	     104 allocs/op
BenchmarkParser-12               	   46203	     25619 ns/op	    3016 B/op	     104 allocs/op
BenchmarkParser-12               	   45882	     25562 ns/op	    3016 B/op	     104 allocs/op
BenchmarkParserWithOptions-12    	   61417	     18942 ns/op	    2184 B/op	      78 allocs/op
BenchmarkParserWithOptions-12    	   62119	     18910 ns/op	    2184 B/op	      78 allocs/op
BenchmarkParserWithOptions-12    	   60931	     18859 ns/op	    2184 B/op	      78 allocs/op
BenchmarkParserWithOptions-12    	   61873	     18857 ns/op	    2184 B/op	      78 allocs/op
BenchmarkParserWithOptions-12    	   62032	     18979 ns/op	    2184 B/op	      78 allocs/op
BenchmarkParserWithOptions-12    	   62133	     18916 ns/op	    2184 B/op	      78 allocs/op
BenchmarkParserWithOptions-12    	   61728	     18924 ns/op	    2184 B/op	      78 allocs/op
BenchmarkParserWithOptions-12    	   61406	     19013 ns/op	    2184 B/op	      78 allocs/op
BenchmarkParserWithOptions-12    	   61411	     18967 ns/op	    2184 B/op	      78 allocs/op
BenchmarkParserWithOptions-12    	   61964	     18752 ns/op	    2184 B/op	      78 allocs/op
PASS
ok  	github.com/ua-parser/uap-go/uaparser	104.198s
```

</details>

<details>

<summary>new.txt</summary>

```
goos: darwin
goarch: amd64
pkg: github.com/ua-parser/uap-go/uaparser
cpu: Intel(R) Core(TM) i5-10600 CPU @ 3.30GHz
BenchmarkParser-12               	  265215	      4524 ns/op	     936 B/op	      52 allocs/op
BenchmarkParser-12               	  265418	      4457 ns/op	     936 B/op	      52 allocs/op
BenchmarkParser-12               	  265468	      4447 ns/op	     936 B/op	      52 allocs/op
BenchmarkParser-12               	  262684	      4427 ns/op	     936 B/op	      52 allocs/op
BenchmarkParser-12               	  268705	      4482 ns/op	     936 B/op	      52 allocs/op
BenchmarkParser-12               	  268242	      4467 ns/op	     936 B/op	      52 allocs/op
BenchmarkParser-12               	  264165	      4477 ns/op	     936 B/op	      52 allocs/op
BenchmarkParser-12               	  267618	      4475 ns/op	     936 B/op	      52 allocs/op
BenchmarkParser-12               	  265178	      4461 ns/op	     936 B/op	      52 allocs/op
BenchmarkParser-12               	  260322	      4513 ns/op	     936 B/op	      52 allocs/op
BenchmarkParserWithOptions-12    	  380679	      3163 ns/op	     728 B/op	      39 allocs/op
BenchmarkParserWithOptions-12    	  381228	      3130 ns/op	     728 B/op	      39 allocs/op
BenchmarkParserWithOptions-12    	  383166	      3152 ns/op	     728 B/op	      39 allocs/op
BenchmarkParserWithOptions-12    	  380457	      3140 ns/op	     728 B/op	      39 allocs/op
BenchmarkParserWithOptions-12    	  371786	      3165 ns/op	     728 B/op	      39 allocs/op
BenchmarkParserWithOptions-12    	  384146	      3155 ns/op	     728 B/op	      39 allocs/op
BenchmarkParserWithOptions-12    	  384008	      3151 ns/op	     728 B/op	      39 allocs/op
BenchmarkParserWithOptions-12    	  379540	      3154 ns/op	     728 B/op	      39 allocs/op
BenchmarkParserWithOptions-12    	  375442	      3154 ns/op	     728 B/op	      39 allocs/op
BenchmarkParserWithOptions-12    	  384351	      3141 ns/op	     728 B/op	      39 allocs/op
PASS
ok  	github.com/ua-parser/uap-go/uaparser	101.055s
```

</details>