### PR TITLE
Add a Github Action to run tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: [ '1.22', '1.23.x' ]
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Go ${{ matrix.go-version }}
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
+
+      - name: Build
+        run: go build -v ./...
+
+      - name: Run tests
+        run: |
+          go version
+          cd uaparser
+          go test -cover ./...


### PR DESCRIPTION
Adding a Github Action to run the tests as instructed by the README.

We can also run the benchmarks and golangci-lint, but I think we should ship this first.

cc @dgoldstein0 