### PR TITLE
Add the ability to configure the parser cache size

### DIFF
--- a/test.go
+++ b/test.go
@@ -3,11 +3,12 @@ package main
 import (
 	"bufio"
 	"fmt"
-	"github.com/ua-parser/uap-go/uaparser"
 	"os"
 	"strconv"
 	"sync"
 	"time"
+
+	"github.com/ua-parser/uap-go/uaparser"
 )
 
 func main() {
@@ -20,7 +21,7 @@ func main() {
 	switch os.Args[1] {
 	case "new":
 		fmt.Println("Running new version of uap...")
-		uaParser, _ := uaparser.NewWithOptions("./uap-core/regexes.yaml", (uaparser.EOsLookUpMode | uaparser.EUserAgentLookUpMode), 100, 20, true, true)
+		uaParser, _ := uaparser.NewWithOptions("./uap-core/regexes.yaml", (uaparser.EOsLookUpMode | uaparser.EUserAgentLookUpMode), 100, 20, true, true, 1024)
 		for i := 0; i < cLevel; i++ {
 			wg.Add(1)
 			go runTest(uaParser, i, &wg)
@@ -38,7 +39,7 @@ func main() {
 		return
 	case "both":
 		fmt.Println("Running new version of uap...")
-		uaParser, _ := uaparser.NewWithOptions("./uap-core/regexes.yaml", (uaparser.EOsLookUpMode | uaparser.EUserAgentLookUpMode), 100, 20, true, true)
+		uaParser, _ := uaparser.NewWithOptions("./uap-core/regexes.yaml", (uaparser.EOsLookUpMode | uaparser.EUserAgentLookUpMode), 100, 20, true, true, 1024)
 		for i := 0; i < cLevel; i++ {
 			wg.Add(1)
 			runTest(uaParser, i, &wg)

--- a/uaparser/cache.go
+++ b/uaparser/cache.go
@@ -12,12 +12,11 @@ type cache struct {
 	userAgent *lru.ARCCache
 }
 
-func newCache() *cache {
+func newCache(cacheSize int) *cache {
 	var (
 		c   cache
 		err error
 	)
-	const cacheSize = 1024
 	// NewARC only fails when cacheSize <= 0.
 	// Also, returning an error up the stack would break the API.
 	c.device, err = lru.NewARC(cacheSize)

--- a/uaparser/parser.go
+++ b/uaparser/parser.go
@@ -128,6 +128,15 @@ type Client struct {
 	Device    *Device
 }
 
+type parserConfig struct {
+	Mode            int
+	UseSort         bool
+	DebugMode       bool
+	CacheSize       int
+	MissesThreshold uint64
+	MatchIdxNotOk   int
+}
+
 type Parser struct {
 	/* atomic operation are done on the following unit64.
 	 * These must be 64bit aligned. On 32bit architectures
@@ -136,13 +145,10 @@ type Parser struct {
 	OsMisses        uint64
 	DeviceMisses    uint64
 
+	config *parserConfig
 	cache *cache
 
 	RegexesDefinitions
-	Mode            int
-	UseSort         bool
-	debugMode       bool
-	cacheSize       int
 }
 
 const (
@@ -153,13 +159,8 @@ const (
 	cDefaultMissesTreshold = 500000
 	cDefaultMatchIdxNotOk  = 20
 	cDefaultSortOption     = false
+	cDefaultDebugMode      = false
 	cDefaultCacheSize      = 1024
-)
-
-var (
-	missesTreshold      = uint64(500000)
-	matchIdxNotOk       = 20
-	parserCacheSize     = 1024
 )
 
 func (parser *Parser) mustCompile() { // until we can use yaml.UnmarshalYAML with embedded pointer struct
@@ -177,27 +178,46 @@ func (parser *Parser) mustCompile() { // until we can use yaml.UnmarshalYAML wit
 	}
 }
 
+func defaultParserConfig() *parserConfig {
+	return &parserConfig{
+		Mode: EOsLookUpMode | EUserAgentLookUpMode | EDeviceLookUpMode,
+		UseSort: cDefaultSortOption,
+		DebugMode: cDefaultDebugMode,
+		CacheSize: cDefaultCacheSize,
+		MissesThreshold: cMinMissesTreshold,
+		MatchIdxNotOk:   cDefaultMatchIdxNotOk,
+	}
+}
+
 func NewWithOptions(regexFile string, mode, treshold, topCnt int, useSort, debugMode bool, cacheSize int) (*Parser, error) {
 	data, err := ioutil.ReadFile(regexFile)
 	if nil != err {
 		return nil, err
 	}
+
+	cfg := &parserConfig{
+		Mode: mode,
+		UseSort: useSort,
+		DebugMode: debugMode,
+		MatchIdxNotOk: cDefaultMatchIdxNotOk,
+		MissesThreshold: cDefaultMissesTreshold,
+		CacheSize: cDefaultCacheSize,
+	}
+
 	if topCnt >= 0 {
-		matchIdxNotOk = topCnt
+		cfg.MatchIdxNotOk = topCnt
 	}
 	if treshold > cMinMissesTreshold {
-		missesTreshold = uint64(treshold)
+		cfg.MissesThreshold = uint64(treshold)
 	}
 	if cacheSize > 0 {
-		parserCacheSize = cacheSize
+		cfg.CacheSize = cacheSize
 	}
-	parser, err := NewFromBytes(data)
+
+	parser, err := newFromBytes(data, cfg)
 	if err != nil {
 		return nil, err
 	}
-	parser.Mode = mode
-	parser.UseSort = useSort
-	parser.debugMode = debugMode
 	return parser, nil
 }
 
@@ -206,10 +226,7 @@ func New(regexFile string) (*Parser, error) {
 	if nil != err {
 		return nil, err
 	}
-	matchIdxNotOk = cDefaultMatchIdxNotOk
-	missesTreshold = cDefaultMissesTreshold
-	parserCacheSize = cDefaultCacheSize
-	parser, err := NewFromBytes(data)
+	parser, err := newFromBytes(data, defaultParserConfig())
 	if err != nil {
 		return nil, err
 	}
@@ -217,7 +234,7 @@ func New(regexFile string) (*Parser, error) {
 }
 
 func NewFromSaved() *Parser {
-	parser, err := NewFromBytes(DefinitionYaml)
+	parser, err := newFromBytes(DefinitionYaml, defaultParserConfig())
 	if err != nil {
 		// if the YAML is malformed, it's a programmatic error inside what
 		// we've statically-compiled in our binary. Panic!
@@ -227,9 +244,13 @@ func NewFromSaved() *Parser {
 }
 
 func NewFromBytes(data []byte) (*Parser, error) {
+	return newFromBytes(data, defaultParserConfig())
+}
+
+func newFromBytes(data []byte, config *parserConfig) (*Parser, error) {
 	parser := &Parser{
-		Mode:  EOsLookUpMode | EUserAgentLookUpMode | EDeviceLookUpMode,
-		cache: newCache(parserCacheSize),
+		config: config,
+		cache: newCache(config.CacheSize),
 	}
 	if err := yaml.Unmarshal(data, &parser.RegexesDefinitions); err != nil {
 		return nil, err
@@ -243,7 +264,7 @@ func NewFromBytes(data []byte) (*Parser, error) {
 func (parser *Parser) Parse(line string) *Client {
 	cli := new(Client)
 	var wg sync.WaitGroup
-	if EUserAgentLookUpMode&parser.Mode == EUserAgentLookUpMode {
+	if EUserAgentLookUpMode&parser.config.Mode == EUserAgentLookUpMode {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -252,7 +273,7 @@ func (parser *Parser) Parse(line string) *Client {
 			parser.RUnlock()
 		}()
 	}
-	if EOsLookUpMode&parser.Mode == EOsLookUpMode {
+	if EOsLookUpMode&parser.config.Mode == EOsLookUpMode {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -261,7 +282,7 @@ func (parser *Parser) Parse(line string) *Client {
 			parser.RUnlock()
 		}()
 	}
-	if EDeviceLookUpMode&parser.Mode == EDeviceLookUpMode {
+	if EDeviceLookUpMode&parser.config.Mode == EDeviceLookUpMode {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -271,7 +292,7 @@ func (parser *Parser) Parse(line string) *Client {
 		}()
 	}
 	wg.Wait()
-	if parser.UseSort == true {
+	if parser.config.UseSort == true {
 		checkAndSort(parser)
 	}
 	return cli
@@ -297,7 +318,7 @@ func (parser *Parser) ParseUserAgent(line string) *UserAgent {
 	if !found {
 		ua.Family = "Other"
 	}
-	if foundIdx > matchIdxNotOk {
+	if foundIdx > parser.config.MatchIdxNotOk {
 		atomic.AddUint64(&parser.UserAgentMisses, 1)
 	}
 	parser.cache.userAgent.Add(line, ua)
@@ -325,7 +346,7 @@ func (parser *Parser) ParseOs(line string) *Os {
 	if !found {
 		os.Family = "Other"
 	}
-	if foundIdx > matchIdxNotOk {
+	if foundIdx > parser.config.MatchIdxNotOk {
 		atomic.AddUint64(&parser.OsMisses, 1)
 	}
 
@@ -354,7 +375,7 @@ func (parser *Parser) ParseDevice(line string) *Device {
 	if !found {
 		dvc.Family = "Other"
 	}
-	if foundIdx > matchIdxNotOk {
+	if foundIdx > parser.config.MatchIdxNotOk {
 		atomic.AddUint64(&parser.DeviceMisses, 1)
 	}
 
@@ -364,8 +385,8 @@ func (parser *Parser) ParseDevice(line string) *Device {
 
 func checkAndSort(parser *Parser) {
 	parser.Lock()
-	if atomic.LoadUint64(&parser.UserAgentMisses) >= missesTreshold {
-		if parser.debugMode {
+	if atomic.LoadUint64(&parser.UserAgentMisses) >= parser.config.MissesThreshold {
+		if parser.config.DebugMode {
 			fmt.Printf("%s\tSorting UserAgents slice\n", time.Now())
 		}
 		parser.UserAgentMisses = 0
@@ -373,8 +394,8 @@ func checkAndSort(parser *Parser) {
 	}
 	parser.Unlock()
 	parser.Lock()
-	if atomic.LoadUint64(&parser.OsMisses) >= missesTreshold {
-		if parser.debugMode {
+	if atomic.LoadUint64(&parser.OsMisses) >= parser.config.MissesThreshold {
+		if parser.config.DebugMode {
 			fmt.Printf("%s\tSorting OS slice\n", time.Now())
 		}
 		parser.OsMisses = 0
@@ -382,8 +403,8 @@ func checkAndSort(parser *Parser) {
 	}
 	parser.Unlock()
 	parser.Lock()
-	if atomic.LoadUint64(&parser.DeviceMisses) >= missesTreshold {
-		if parser.debugMode {
+	if atomic.LoadUint64(&parser.DeviceMisses) >= parser.config.MissesThreshold {
+		if parser.config.DebugMode {
 			fmt.Printf("%s\tSorting Device slice\n", time.Now())
 		}
 		parser.DeviceMisses = 0


### PR DESCRIPTION
The PR introduces the ability to configure the parser cache size. It turns out that the current value (1024) is not always suitable for all use cases and sometimes significantly slows down the parser. Here is a benchmark that shows the problem:

```
BenchmarkParserWithDifferentCacheSize/CacheSize=1024-16                     5342            199881 ns/op
BenchmarkParserWithDifferentCacheSize/CacheSize=1024-16                     5947            204456 ns/op
BenchmarkParserWithDifferentCacheSize/CacheSize=1024-16                     6093            201764 ns/op
BenchmarkParserWithDifferentCacheSize/CacheSize=2048-16                    18164             68316 ns/op
BenchmarkParserWithDifferentCacheSize/CacheSize=2048-16                    18910             65478 ns/op
BenchmarkParserWithDifferentCacheSize/CacheSize=2048-16                    18656             65256 ns/op
BenchmarkParserWithDifferentCacheSize/CacheSize=3072-16                   463863              2279 ns/op
BenchmarkParserWithDifferentCacheSize/CacheSize=3072-16                   531889              2137 ns/op
BenchmarkParserWithDifferentCacheSize/CacheSize=3072-16                   520400              2156 ns/op
BenchmarkParserWithDifferentCacheSize/CacheSize=4096-16                   501780              2169 ns/op
BenchmarkParserWithDifferentCacheSize/CacheSize=4096-16                   508465              2188 ns/op
BenchmarkParserWithDifferentCacheSize/CacheSize=4096-16                   517063              2156 ns/op
BenchmarkParserWithDifferentCacheSize/CacheSize=5120-16                   490534              2203 ns/op
BenchmarkParserWithDifferentCacheSize/CacheSize=5120-16                   514162              2205 ns/op
BenchmarkParserWithDifferentCacheSize/CacheSize=5120-16                   480238              2320 ns/op
```

As you can see, the parser with the default cache value for the UA sample strings you have in your repository is almost 100x slower compared to the parser with cacheSize=4k. We see the same issue with our data, but it seems like the sweet spot for us is somewhere around 2k.

The PR adds a new option to the `NewWithOptions` method, which essentially breaks backward compatibility with the old version of the library. Unfortunately, I don't see any other way to add it given the current design of the API, so maybe you have other suggestions on how to add it more correctly.

Thank you!