### PR TITLE
feat!: Introduce New function with functional options pattern 

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ package main
 import (
   "fmt"
   "log"
+  "os"
 
   "github.com/ua-parser/uap-go/uaparser"
 )
@@ -49,7 +50,13 @@ import (
 func main() {
   uagent := "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_3; en-us; Silk/1.1.0-80) AppleWebKit/533.16 (KHTML, like Gecko) Version/5.0 Safari/533.16 Silk-Accelerated=true"
 
-  parser, err := uaparser.New("./regexes.yaml")
+
+  regexes, err := os.ReadFile("./regexes.yaml")
+  if err != nil {
+	  log.Fatal(err)
+  }
+  
+  parser, err := uaparser.New(regexes)
   if err != nil {
     log.Fatal(err)
   }

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ import (
   "os"
 
   "github.com/ua-parser/uap-go/uaparser"
+  "gopkg.in/yaml.v3"
 )
 
 func main() {
@@ -55,8 +56,15 @@ func main() {
   if err != nil {
 	  log.Fatal(err)
   }
+
+  var def *uaparser.RegexesDefinitions
+
+  if err := yaml.Unmarshal(regexes, def); err != nil {
+    fmt.Printf("error parsing regexes definitions. Error: %s\n", err.Error())
+    return
+  }
   
-  parser, err := uaparser.New(regexes)
+  parser, err := uaparser.New(uaparser.WithRegexesDefinitions(def))
   if err != nil {
     log.Fatal(err)
   }

--- a/test.go
+++ b/test.go
@@ -39,9 +39,8 @@ func main() {
 		uaParser, _ := uaparser.New(
 			uaparser.WithRegexDefinitions(def),
 			uaparser.WithMode(uaparser.EOsLookUpMode|uaparser.EUserAgentLookUpMode),
-			uaparser.WithMissesThreshold(100),
 			uaparser.WithMatchIdxNotOk(20),
-			uaparser.WithSort(true),
+			uaparser.WithSort(true, uaparser.WithMissesThreshold(100)),
 			uaparser.WithDebug(true),
 			uaparser.WithCacheSize(1024),
 		)
@@ -65,9 +64,8 @@ func main() {
 		uaParser, _ := uaparser.New(
 			uaparser.WithRegexDefinitions(def),
 			uaparser.WithMode(uaparser.EOsLookUpMode|uaparser.EUserAgentLookUpMode),
-			uaparser.WithMissesThreshold(100),
 			uaparser.WithMatchIdxNotOk(20),
-			uaparser.WithSort(true),
+			uaparser.WithSort(true, uaparser.WithMissesThreshold(100)),
 			uaparser.WithDebug(true),
 			uaparser.WithCacheSize(1024),
 		)

--- a/test.go
+++ b/test.go
@@ -24,9 +24,9 @@ func main() {
 		return
 	}
 
-	var def *uaparser.RegexesDefinitions
+	var def uaparser.RegexDefinitions
 
-	if err := yaml.Unmarshal(regexes, def); err != nil {
+	if err := yaml.Unmarshal(regexes, &def); err != nil {
 		fmt.Printf("error parsing regexes definitions. Error: %s\n", err.Error())
 		return
 	}
@@ -37,7 +37,7 @@ func main() {
 	case "new":
 		fmt.Println("Running new version of uap...")
 		uaParser, _ := uaparser.New(
-			uaparser.WithRegexesDefinitions(def),
+			uaparser.WithRegexDefinitions(def),
 			uaparser.WithMode(uaparser.EOsLookUpMode|uaparser.EUserAgentLookUpMode),
 			uaparser.WithMissesThreshold(100),
 			uaparser.WithMatchIdxNotOk(20),
@@ -53,7 +53,7 @@ func main() {
 		return
 	case "old":
 		fmt.Println("Running old version of uap...")
-		uaParser, _ := uaparser.New(uaparser.WithRegexesDefinitions(def))
+		uaParser, _ := uaparser.New(uaparser.WithRegexDefinitions(def))
 		for i := 0; i < cLevel; i++ {
 			wg.Add(1)
 			go runTest(uaParser, i, &wg)
@@ -63,7 +63,7 @@ func main() {
 	case "both":
 		fmt.Println("Running new version of uap...")
 		uaParser, _ := uaparser.New(
-			uaparser.WithRegexesDefinitions(def),
+			uaparser.WithRegexDefinitions(def),
 			uaparser.WithMode(uaparser.EOsLookUpMode|uaparser.EUserAgentLookUpMode),
 			uaparser.WithMissesThreshold(100),
 			uaparser.WithMatchIdxNotOk(20),
@@ -76,7 +76,7 @@ func main() {
 			runTest(uaParser, i, &wg)
 		}
 		fmt.Println("Running old version of uap...")
-		uaParser, _ = uaparser.New(uaparser.WithRegexesDefinitions(def))
+		uaParser, _ = uaparser.New(uaparser.WithRegexDefinitions(def))
 		for i := 0; i < cLevel; i++ {
 			wg.Add(1)
 			runTest(uaParser, i, &wg)

--- a/test.go
+++ b/test.go
@@ -16,12 +16,26 @@ func main() {
 		fmt.Printf("Usage: %s [old|new|both] [concurrency level]\n", os.Args[0])
 		return
 	}
+
+	regexes, err := os.ReadFile("./uap-core/regexes.yaml")
+	if err != nil {
+		fmt.Printf("Failed to read regexes file. Error: %s\n", err.Error())
+		return
+	}
+
 	var wg sync.WaitGroup
 	cLevel, _ := strconv.Atoi(os.Args[2])
 	switch os.Args[1] {
 	case "new":
 		fmt.Println("Running new version of uap...")
-		uaParser, _ := uaparser.NewWithOptions("./uap-core/regexes.yaml", (uaparser.EOsLookUpMode | uaparser.EUserAgentLookUpMode), 100, 20, true, true, 1024)
+		uaParser, _ := uaparser.New(regexes,
+			uaparser.WithMode(uaparser.EOsLookUpMode|uaparser.EUserAgentLookUpMode),
+			uaparser.WithMissesThreshold(100),
+			uaparser.WithMatchIdxNotOk(20),
+			uaparser.WithSort(true),
+			uaparser.WithDebug(true),
+			uaparser.WithCacheSize(1024),
+		)
 		for i := 0; i < cLevel; i++ {
 			wg.Add(1)
 			go runTest(uaParser, i, &wg)
@@ -30,7 +44,7 @@ func main() {
 		return
 	case "old":
 		fmt.Println("Running old version of uap...")
-		uaParser, _ := uaparser.New("./uap-core/regexes.yaml")
+		uaParser, _ := uaparser.New(regexes)
 		for i := 0; i < cLevel; i++ {
 			wg.Add(1)
 			go runTest(uaParser, i, &wg)
@@ -39,13 +53,20 @@ func main() {
 		return
 	case "both":
 		fmt.Println("Running new version of uap...")
-		uaParser, _ := uaparser.NewWithOptions("./uap-core/regexes.yaml", (uaparser.EOsLookUpMode | uaparser.EUserAgentLookUpMode), 100, 20, true, true, 1024)
+		uaParser, _ := uaparser.New(regexes,
+			uaparser.WithMode(uaparser.EOsLookUpMode|uaparser.EUserAgentLookUpMode),
+			uaparser.WithMissesThreshold(100),
+			uaparser.WithMatchIdxNotOk(20),
+			uaparser.WithSort(true),
+			uaparser.WithDebug(true),
+			uaparser.WithCacheSize(1024),
+		)
 		for i := 0; i < cLevel; i++ {
 			wg.Add(1)
 			runTest(uaParser, i, &wg)
 		}
 		fmt.Println("Running old version of uap...")
-		uaParser, _ = uaparser.New("./uap-core/regexes.yaml")
+		uaParser, _ = uaparser.New(regexes)
 		for i := 0; i < cLevel; i++ {
 			wg.Add(1)
 			runTest(uaParser, i, &wg)

--- a/test.go
+++ b/test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/ua-parser/uap-go/uaparser"
+	"gopkg.in/yaml.v3"
 )
 
 func main() {
@@ -23,12 +24,20 @@ func main() {
 		return
 	}
 
+	var def *uaparser.RegexesDefinitions
+
+	if err := yaml.Unmarshal(regexes, def); err != nil {
+		fmt.Printf("error parsing regexes definitions. Error: %s\n", err.Error())
+		return
+	}
+
 	var wg sync.WaitGroup
 	cLevel, _ := strconv.Atoi(os.Args[2])
 	switch os.Args[1] {
 	case "new":
 		fmt.Println("Running new version of uap...")
-		uaParser, _ := uaparser.New(regexes,
+		uaParser, _ := uaparser.New(
+			uaparser.WithRegexesDefinitions(def),
 			uaparser.WithMode(uaparser.EOsLookUpMode|uaparser.EUserAgentLookUpMode),
 			uaparser.WithMissesThreshold(100),
 			uaparser.WithMatchIdxNotOk(20),
@@ -44,7 +53,7 @@ func main() {
 		return
 	case "old":
 		fmt.Println("Running old version of uap...")
-		uaParser, _ := uaparser.New(regexes)
+		uaParser, _ := uaparser.New(uaparser.WithRegexesDefinitions(def))
 		for i := 0; i < cLevel; i++ {
 			wg.Add(1)
 			go runTest(uaParser, i, &wg)
@@ -53,7 +62,8 @@ func main() {
 		return
 	case "both":
 		fmt.Println("Running new version of uap...")
-		uaParser, _ := uaparser.New(regexes,
+		uaParser, _ := uaparser.New(
+			uaparser.WithRegexesDefinitions(def),
 			uaparser.WithMode(uaparser.EOsLookUpMode|uaparser.EUserAgentLookUpMode),
 			uaparser.WithMissesThreshold(100),
 			uaparser.WithMatchIdxNotOk(20),
@@ -66,7 +76,7 @@ func main() {
 			runTest(uaParser, i, &wg)
 		}
 		fmt.Println("Running old version of uap...")
-		uaParser, _ = uaparser.New(regexes)
+		uaParser, _ = uaparser.New(uaparser.WithRegexesDefinitions(def))
 		for i := 0; i < cLevel; i++ {
 			wg.Add(1)
 			runTest(uaParser, i, &wg)

--- a/uaparser/benchmark_test.go
+++ b/uaparser/benchmark_test.go
@@ -23,7 +23,7 @@ func init() {
 		log.Fatal(err)
 	}
 
-	var def *RegexesDefinitions
+	def := &RegexesDefinitions{}
 
 	if err := yaml.Unmarshal(regexes, def); err != nil {
 		log.Fatal(err)
@@ -77,7 +77,7 @@ func BenchmarkParserWithDifferentCacheSize(b *testing.B) {
 		log.Fatal(err)
 	}
 
-	var def *RegexesDefinitions
+	def := &RegexesDefinitions{}
 
 	if err := yaml.Unmarshal(regexes, def); err != nil {
 		log.Fatal(err)

--- a/uaparser/benchmark_test.go
+++ b/uaparser/benchmark_test.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 )
 
 var benchedParser *Parser
@@ -21,11 +23,17 @@ func init() {
 		log.Fatal(err)
 	}
 
-	benchedParser, err = New(regexes)
+	var def *RegexesDefinitions
+
+	if err := yaml.Unmarshal(regexes, def); err != nil {
+		log.Fatal(err)
+	}
+
+	benchedParser, err = New(WithRegexesDefinitions(def))
 	if err != nil {
 		log.Fatal(err)
 	}
-	benchedParserWithOptions, err = New(regexes,
+	benchedParserWithOptions, err = New(WithRegexesDefinitions(def),
 		WithMode(EOsLookUpMode|EUserAgentLookUpMode),
 		WithMissesThreshold(100),
 		WithMatchIdxNotOk(20),
@@ -69,8 +77,14 @@ func BenchmarkParserWithDifferentCacheSize(b *testing.B) {
 		log.Fatal(err)
 	}
 
+	var def *RegexesDefinitions
+
+	if err := yaml.Unmarshal(regexes, def); err != nil {
+		log.Fatal(err)
+	}
+
 	for _, size := range sizes {
-		parser, err := New(regexes,
+		parser, err := New(WithRegexesDefinitions(def),
 			WithMode(EOsLookUpMode|EUserAgentLookUpMode|EDeviceLookUpMode),
 			WithMissesThreshold(cDefaultMissesTreshold),
 			WithMatchIdxNotOk(cDefaultMatchIdxNotOk),

--- a/uaparser/benchmark_test.go
+++ b/uaparser/benchmark_test.go
@@ -15,11 +15,25 @@ var largeUasSample []string
 
 func init() {
 	var err error
-	benchedParser, err = New("../uap-core/regexes.yaml")
+
+	regexes, err := os.ReadFile("../uap-core/regexes.yaml")
 	if err != nil {
 		log.Fatal(err)
 	}
-	benchedParserWithOptions, err = NewWithOptions("../uap-core/regexes.yaml", (EOsLookUpMode | EUserAgentLookUpMode), 100, 20, true, true, cDefaultCacheSize)
+
+	benchedParser, err = New(regexes)
+	if err != nil {
+		log.Fatal(err)
+	}
+	benchedParserWithOptions, err = New(regexes,
+		WithMode(EOsLookUpMode|EUserAgentLookUpMode),
+		WithMissesThreshold(100),
+		WithMatchIdxNotOk(20),
+		WithSort(true),
+		WithDebug(true),
+		WithCacheSize(cDefaultCacheSize),
+	)
+
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -48,17 +62,22 @@ func BenchmarkParserWithOptions(b *testing.B) {
 }
 
 func BenchmarkParserWithDifferentCacheSize(b *testing.B) {
-	sizes := []int{cDefaultCacheSize, cDefaultCacheSize*2, cDefaultCacheSize*3, cDefaultCacheSize*4}
+	sizes := []int{cDefaultCacheSize, cDefaultCacheSize * 2, cDefaultCacheSize * 3, cDefaultCacheSize * 4}
+
+	regexes, err := os.ReadFile("../uap-core/regexes.yaml")
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	for _, size := range sizes {
-		parser, err := NewWithOptions(
-			"../uap-core/regexes.yaml",
-			EOsLookUpMode | EUserAgentLookUpMode | EDeviceLookUpMode,
-			cDefaultMissesTreshold,
-			cDefaultMatchIdxNotOk,
-			false,
-			false,
-			size)
+		parser, err := New(regexes,
+			WithMode(EOsLookUpMode|EUserAgentLookUpMode|EDeviceLookUpMode),
+			WithMissesThreshold(cDefaultMissesTreshold),
+			WithMatchIdxNotOk(cDefaultMatchIdxNotOk),
+			WithSort(false),
+			WithDebug(false),
+			WithCacheSize(size),
+		)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/uaparser/benchmark_test.go
+++ b/uaparser/benchmark_test.go
@@ -35,9 +35,8 @@ func init() {
 	}
 	benchedParserWithOptions, err = New(WithRegexDefinitions(def),
 		WithMode(EOsLookUpMode|EUserAgentLookUpMode),
-		WithMissesThreshold(100),
 		WithMatchIdxNotOk(20),
-		WithSort(true),
+		WithSort(true, WithMissesThreshold(100)),
 		WithDebug(true),
 		WithCacheSize(cDefaultCacheSize),
 	)
@@ -86,9 +85,8 @@ func BenchmarkParserWithDifferentCacheSize(b *testing.B) {
 	for _, size := range sizes {
 		parser, err := New(WithRegexDefinitions(def),
 			WithMode(EOsLookUpMode|EUserAgentLookUpMode|EDeviceLookUpMode),
-			WithMissesThreshold(cDefaultMissesTreshold),
 			WithMatchIdxNotOk(cDefaultMatchIdxNotOk),
-			WithSort(false),
+			WithSort(false, WithMissesThreshold(cDefaultMissesTreshold)),
 			WithDebug(false),
 			WithCacheSize(size),
 		)

--- a/uaparser/benchmark_test.go
+++ b/uaparser/benchmark_test.go
@@ -23,17 +23,17 @@ func init() {
 		log.Fatal(err)
 	}
 
-	var def RegexesDefinitions
+	var def RegexDefinitions
 
 	if err := yaml.Unmarshal(regexes, &def); err != nil {
 		log.Fatal(err)
 	}
 
-	benchedParser, err = New(WithRegexesDefinitions(def))
+	benchedParser, err = New(WithRegexDefinitions(def))
 	if err != nil {
 		log.Fatal(err)
 	}
-	benchedParserWithOptions, err = New(WithRegexesDefinitions(def),
+	benchedParserWithOptions, err = New(WithRegexDefinitions(def),
 		WithMode(EOsLookUpMode|EUserAgentLookUpMode),
 		WithMissesThreshold(100),
 		WithMatchIdxNotOk(20),
@@ -77,14 +77,14 @@ func BenchmarkParserWithDifferentCacheSize(b *testing.B) {
 		log.Fatal(err)
 	}
 
-	var def RegexesDefinitions
+	var def RegexDefinitions
 
 	if err := yaml.Unmarshal(regexes, &def); err != nil {
 		log.Fatal(err)
 	}
 
 	for _, size := range sizes {
-		parser, err := New(WithRegexesDefinitions(def),
+		parser, err := New(WithRegexDefinitions(def),
 			WithMode(EOsLookUpMode|EUserAgentLookUpMode|EDeviceLookUpMode),
 			WithMissesThreshold(cDefaultMissesTreshold),
 			WithMatchIdxNotOk(cDefaultMatchIdxNotOk),

--- a/uaparser/benchmark_test.go
+++ b/uaparser/benchmark_test.go
@@ -23,9 +23,9 @@ func init() {
 		log.Fatal(err)
 	}
 
-	def := &RegexesDefinitions{}
+	var def RegexesDefinitions
 
-	if err := yaml.Unmarshal(regexes, def); err != nil {
+	if err := yaml.Unmarshal(regexes, &def); err != nil {
 		log.Fatal(err)
 	}
 
@@ -77,9 +77,9 @@ func BenchmarkParserWithDifferentCacheSize(b *testing.B) {
 		log.Fatal(err)
 	}
 
-	def := &RegexesDefinitions{}
+	var def RegexesDefinitions
 
-	if err := yaml.Unmarshal(regexes, def); err != nil {
+	if err := yaml.Unmarshal(regexes, &def); err != nil {
 		log.Fatal(err)
 	}
 

--- a/uaparser/deprecated.go
+++ b/uaparser/deprecated.go
@@ -32,7 +32,7 @@ func NewWithOptions(regexFile string, mode, treshold, topCnt int, useSort, debug
 }
 
 // NewFromSaved is deprecated.
-// Deprecated: Use New and option functions instead.
+// Deprecated: Use New() instead.
 func NewFromSaved() *Parser {
 	parser, err := New()
 	if err != nil {

--- a/uaparser/deprecated.go
+++ b/uaparser/deprecated.go
@@ -45,7 +45,7 @@ func NewFromSaved() *Parser {
 }
 
 // NewFromBytes is deprecated.
-// Deprecated: Use New and option functions instead.
+// Deprecated: Use New(WithRegexDefintions(...)) instead
 func NewFromBytes(data []byte) (*Parser, error) {
 	var def *RegexesDefinitions
 

--- a/uaparser/deprecated.go
+++ b/uaparser/deprecated.go
@@ -23,9 +23,8 @@ func NewWithOptions(regexFile string, mode, treshold, topCnt int, useSort, debug
 	return New(
 		WithRegexDefinitions(def),
 		WithMode(LookupMode(mode)),
-		WithMissesThreshold(uint64(treshold)),
 		WithMatchIdxNotOk(topCnt),
-		WithSort(useSort),
+		WithSort(useSort, WithMissesThreshold(uint64(treshold))),
 		WithDebug(debugMode),
 		WithCacheSize(cacheSize),
 	)

--- a/uaparser/deprecated.go
+++ b/uaparser/deprecated.go
@@ -14,7 +14,7 @@ func NewWithOptions(regexFile string, mode, treshold, topCnt int, useSort, debug
 		return nil, err
 	}
 
-	var def *RegexesDefinitions
+	def := &RegexesDefinitions{}
 
 	if err := yaml.Unmarshal(uaRegexes, def); err != nil {
 		return nil, err
@@ -47,7 +47,7 @@ func NewFromSaved() *Parser {
 // NewFromBytes is deprecated.
 // Deprecated: Use New(WithRegexDefintions(...)) instead
 func NewFromBytes(data []byte) (*Parser, error) {
-	var def *RegexesDefinitions
+	def := &RegexesDefinitions{}
 
 	if err := yaml.Unmarshal(data, def); err != nil {
 		return nil, err

--- a/uaparser/deprecated.go
+++ b/uaparser/deprecated.go
@@ -14,14 +14,14 @@ func NewWithOptions(regexFile string, mode, treshold, topCnt int, useSort, debug
 		return nil, err
 	}
 
-	var def RegexesDefinitions
+	var def RegexDefinitions
 
 	if err := yaml.Unmarshal(uaRegexes, &def); err != nil {
 		return nil, err
 	}
 
 	return New(
-		WithRegexesDefinitions(def),
+		WithRegexDefinitions(def),
 		WithMode(LookupMode(mode)),
 		WithMissesThreshold(uint64(treshold)),
 		WithMatchIdxNotOk(topCnt),
@@ -45,13 +45,13 @@ func NewFromSaved() *Parser {
 }
 
 // NewFromBytes is deprecated.
-// Deprecated: Use New(WithRegexDefintions(...)) instead
+// Deprecated: Use New(WithRegexDefinitions(...)) instead
 func NewFromBytes(data []byte) (*Parser, error) {
-	var def RegexesDefinitions
+	var def RegexDefinitions
 
 	if err := yaml.Unmarshal(data, &def); err != nil {
 		return nil, err
 	}
 
-	return New(WithRegexesDefinitions(def))
+	return New(WithRegexDefinitions(def))
 }

--- a/uaparser/deprecated.go
+++ b/uaparser/deprecated.go
@@ -1,0 +1,57 @@
+package uaparser
+
+import (
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// NewWithOptions is deprecated.
+// Deprecated: Use New and option functions instead.
+func NewWithOptions(regexFile string, mode, treshold, topCnt int, useSort, debugMode bool, cacheSize int) (*Parser, error) {
+	uaRegexes, err := os.ReadFile(regexFile)
+	if err != nil {
+		return nil, err
+	}
+
+	var def *RegexesDefinitions
+
+	if err := yaml.Unmarshal(uaRegexes, def); err != nil {
+		return nil, err
+	}
+
+	return New(
+		WithRegexesDefinitions(def),
+		WithMode(LookupMode(mode)),
+		WithMissesThreshold(uint64(treshold)),
+		WithMatchIdxNotOk(topCnt),
+		WithSort(useSort),
+		WithDebug(debugMode),
+		WithCacheSize(cacheSize),
+	)
+}
+
+// NewFromSaved is deprecated.
+// Deprecated: Use New and option functions instead.
+func NewFromSaved() *Parser {
+	parser, err := New()
+	if err != nil {
+		// if the YAML is malformed, it's a programmatic error inside what
+		// we've statically-compiled in our binary. Panic!
+		panic(err.Error())
+	}
+
+	return parser
+}
+
+// NewFromBytes is deprecated.
+// Deprecated: Use New and option functions instead.
+func NewFromBytes(data []byte) (*Parser, error) {
+	var def *RegexesDefinitions
+
+	if err := yaml.Unmarshal(data, def); err != nil {
+		return nil, err
+	}
+
+	return New(WithRegexesDefinitions(def))
+}

--- a/uaparser/deprecated.go
+++ b/uaparser/deprecated.go
@@ -14,9 +14,9 @@ func NewWithOptions(regexFile string, mode, treshold, topCnt int, useSort, debug
 		return nil, err
 	}
 
-	def := &RegexesDefinitions{}
+	var def RegexesDefinitions
 
-	if err := yaml.Unmarshal(uaRegexes, def); err != nil {
+	if err := yaml.Unmarshal(uaRegexes, &def); err != nil {
 		return nil, err
 	}
 
@@ -47,9 +47,9 @@ func NewFromSaved() *Parser {
 // NewFromBytes is deprecated.
 // Deprecated: Use New(WithRegexDefintions(...)) instead
 func NewFromBytes(data []byte) (*Parser, error) {
-	def := &RegexesDefinitions{}
+	var def RegexesDefinitions
 
-	if err := yaml.Unmarshal(data, def); err != nil {
+	if err := yaml.Unmarshal(data, &def); err != nil {
 		return nil, err
 	}
 

--- a/uaparser/device.go
+++ b/uaparser/device.go
@@ -8,20 +8,20 @@ type Device struct {
 	Model  string
 }
 
-func (parser *deviceParser) Match(line string, dvc *Device) {
-	matches := parser.Reg.FindStringSubmatchIndex(line)
+func (dp *deviceParser) Match(line string, dvc *Device) {
+	matches := dp.Reg.FindStringSubmatchIndex(line)
 
 	if len(matches) == 0 {
 		return
 	}
 
-	dvc.Family = string(parser.Reg.ExpandString(nil, parser.DeviceReplacement, line, matches))
+	dvc.Family = string(dp.Reg.ExpandString(nil, dp.DeviceReplacement, line, matches))
 	dvc.Family = strings.TrimSpace(dvc.Family)
 
-	dvc.Brand = string(parser.Reg.ExpandString(nil, parser.BrandReplacement, line, matches))
+	dvc.Brand = string(dp.Reg.ExpandString(nil, dp.BrandReplacement, line, matches))
 	dvc.Brand = strings.TrimSpace(dvc.Brand)
 
-	dvc.Model = string(parser.Reg.ExpandString(nil, parser.ModelReplacement, line, matches))
+	dvc.Model = string(dp.Reg.ExpandString(nil, dp.ModelReplacement, line, matches))
 	dvc.Model = strings.TrimSpace(dvc.Model)
 }
 

--- a/uaparser/options.go
+++ b/uaparser/options.go
@@ -38,8 +38,8 @@ func WithMatchIdxNotOk(idx int) Option {
 	}
 }
 
-func WithRegexesDefinitions(def *RegexesDefinitions) Option {
+func WithRegexesDefinitions(def RegexesDefinitions) Option {
 	return func(s *Parser) {
-		s.RegexesDefinitions = def
+		s.RegexesDefinitions = &def
 	}
 }

--- a/uaparser/options.go
+++ b/uaparser/options.go
@@ -8,9 +8,13 @@ func WithMode(mode LookupMode) Option {
 	}
 }
 
-func WithSort(useSort bool) Option {
+func WithSort(useSort bool, options ...SortOption) Option {
 	return func(s *Parser) {
 		s.config.UseSort = useSort
+
+		for _, o := range options {
+			o(s)
+		}
 	}
 }
 
@@ -26,12 +30,6 @@ func WithCacheSize(size int) Option {
 	}
 }
 
-func WithMissesThreshold(threshold uint64) Option {
-	return func(s *Parser) {
-		s.config.MissesThreshold = threshold
-	}
-}
-
 func WithMatchIdxNotOk(idx int) Option {
 	return func(s *Parser) {
 		s.config.MatchIdxNotOk = idx
@@ -41,5 +39,13 @@ func WithMatchIdxNotOk(idx int) Option {
 func WithRegexDefinitions(def RegexDefinitions) Option {
 	return func(s *Parser) {
 		s.RegexDefinitions = &def
+	}
+}
+
+type SortOption func(*Parser)
+
+func WithMissesThreshold(threshold uint64) SortOption {
+	return func(s *Parser) {
+		s.config.MissesThreshold = threshold
 	}
 }

--- a/uaparser/options.go
+++ b/uaparser/options.go
@@ -37,3 +37,9 @@ func WithMatchIdxNotOk(idx int) Option {
 		s.config.MatchIdxNotOk = idx
 	}
 }
+
+func WithRegexesDefinitions(def *RegexesDefinitions) Option {
+	return func(s *Parser) {
+		s.RegexesDefinitions = def
+	}
+}

--- a/uaparser/options.go
+++ b/uaparser/options.go
@@ -38,8 +38,8 @@ func WithMatchIdxNotOk(idx int) Option {
 	}
 }
 
-func WithRegexesDefinitions(def RegexesDefinitions) Option {
+func WithRegexDefinitions(def RegexDefinitions) Option {
 	return func(s *Parser) {
-		s.RegexesDefinitions = &def
+		s.RegexDefinitions = &def
 	}
 }

--- a/uaparser/options.go
+++ b/uaparser/options.go
@@ -1,0 +1,39 @@
+package uaparser
+
+type Option func(*Parser)
+
+func WithMode(mode LookupMode) Option {
+	return func(s *Parser) {
+		s.config.Mode = mode
+	}
+}
+
+func WithSort(useSort bool) Option {
+	return func(s *Parser) {
+		s.config.UseSort = useSort
+	}
+}
+
+func WithDebug(debug bool) Option {
+	return func(s *Parser) {
+		s.config.DebugMode = debug
+	}
+}
+
+func WithCacheSize(size int) Option {
+	return func(s *Parser) {
+		s.config.CacheSize = size
+	}
+}
+
+func WithMissesThreshold(threshold uint64) Option {
+	return func(s *Parser) {
+		s.config.MissesThreshold = threshold
+	}
+}
+
+func WithMatchIdxNotOk(idx int) Option {
+	return func(s *Parser) {
+		s.config.MatchIdxNotOk = idx
+	}
+}

--- a/uaparser/os.go
+++ b/uaparser/os.go
@@ -8,14 +8,14 @@ type Os struct {
 	PatchMinor string `yaml:"patch_minor"`
 }
 
-func (parser *osParser) Match(line string, os *Os) {
-	matches := parser.Reg.FindStringSubmatchIndex(line)
+func (osp *osParser) Match(line string, os *Os) {
+	matches := osp.Reg.FindStringSubmatchIndex(line)
 	if len(matches) > 0 {
-		os.Family = string(parser.Reg.ExpandString(nil, parser.OSReplacement, line, matches))
-		os.Major = string(parser.Reg.ExpandString(nil, parser.V1Replacement, line, matches))
-		os.Minor = string(parser.Reg.ExpandString(nil, parser.V2Replacement, line, matches))
-		os.Patch = string(parser.Reg.ExpandString(nil, parser.V3Replacement, line, matches))
-		os.PatchMinor = string(parser.Reg.ExpandString(nil, parser.V4Replacement, line, matches))
+		os.Family = string(osp.Reg.ExpandString(nil, osp.OSReplacement, line, matches))
+		os.Major = string(osp.Reg.ExpandString(nil, osp.V1Replacement, line, matches))
+		os.Minor = string(osp.Reg.ExpandString(nil, osp.V2Replacement, line, matches))
+		os.Patch = string(osp.Reg.ExpandString(nil, osp.V3Replacement, line, matches))
+		os.PatchMinor = string(osp.Reg.ExpandString(nil, osp.V4Replacement, line, matches))
 	}
 }
 

--- a/uaparser/parser.go
+++ b/uaparser/parser.go
@@ -26,6 +26,32 @@ type RegexDefinitions struct {
 	Device []*deviceParser `yaml:"device_parsers"`
 }
 
+func (rd *RegexDefinitions) Clone() *RegexDefinitions {
+	if rd == nil {
+		return nil
+	}
+
+	rd2 := &RegexDefinitions{
+		UA:     make([]*uaParser, len(rd.UA)),
+		OS:     make([]*osParser, len(rd.OS)),
+		Device: make([]*deviceParser, len(rd.Device)),
+	}
+
+	for i, v := range rd.UA {
+		rd2.UA[i] = v.Clone()
+	}
+
+	for i, v := range rd.OS {
+		rd2.OS[i] = v.Clone()
+	}
+
+	for i, v := range rd.Device {
+		rd2.Device[i] = v.Clone()
+	}
+
+	return rd2
+}
+
 type UserAgentSorter []*uaParser
 
 func (a UserAgentSorter) Len() int      { return len(a) }
@@ -46,18 +72,29 @@ type uaParser struct {
 	MatchesCount      uint64
 }
 
-func (ua *uaParser) setDefaults() {
-	if ua.FamilyReplacement == "" {
-		ua.FamilyReplacement = "$1"
+func (uap *uaParser) Clone() *uaParser {
+	if uap == nil {
+		return nil
 	}
-	if ua.V1Replacement == "" {
-		ua.V1Replacement = "$2"
+
+	ua2 := *uap
+	ua2.MatchesCount = 0
+
+	return &ua2
+}
+
+func (uap *uaParser) setDefaults() {
+	if uap.FamilyReplacement == "" {
+		uap.FamilyReplacement = "$1"
 	}
-	if ua.V2Replacement == "" {
-		ua.V2Replacement = "$3"
+	if uap.V1Replacement == "" {
+		uap.V1Replacement = "$2"
 	}
-	if ua.V3Replacement == "" {
-		ua.V3Replacement = "$4"
+	if uap.V2Replacement == "" {
+		uap.V2Replacement = "$3"
+	}
+	if uap.V3Replacement == "" {
+		uap.V3Replacement = "$4"
 	}
 }
 
@@ -82,21 +119,32 @@ type osParser struct {
 	MatchesCount  uint64
 }
 
-func (os *osParser) setDefaults() {
-	if os.OSReplacement == "" {
-		os.OSReplacement = "$1"
+func (osp *osParser) Clone() *osParser {
+	if osp == nil {
+		return nil
 	}
-	if os.V1Replacement == "" {
-		os.V1Replacement = "$2"
+
+	os2 := *osp
+	os2.MatchesCount = 0
+
+	return &os2
+}
+
+func (osp *osParser) setDefaults() {
+	if osp.OSReplacement == "" {
+		osp.OSReplacement = "$1"
 	}
-	if os.V2Replacement == "" {
-		os.V2Replacement = "$3"
+	if osp.V1Replacement == "" {
+		osp.V1Replacement = "$2"
 	}
-	if os.V3Replacement == "" {
-		os.V3Replacement = "$4"
+	if osp.V2Replacement == "" {
+		osp.V2Replacement = "$3"
 	}
-	if os.V4Replacement == "" {
-		os.V4Replacement = "$5"
+	if osp.V3Replacement == "" {
+		osp.V3Replacement = "$4"
+	}
+	if osp.V4Replacement == "" {
+		osp.V4Replacement = "$5"
 	}
 }
 
@@ -119,12 +167,23 @@ type deviceParser struct {
 	MatchesCount      uint64
 }
 
-func (device *deviceParser) setDefaults() {
-	if device.DeviceReplacement == "" {
-		device.DeviceReplacement = "$1"
+func (dp *deviceParser) Clone() *deviceParser {
+	if dp == nil {
+		return nil
 	}
-	if device.ModelReplacement == "" {
-		device.ModelReplacement = "$1"
+
+	device2 := *dp
+	device2.MatchesCount = 0
+
+	return &device2
+}
+
+func (dp *deviceParser) setDefaults() {
+	if dp.DeviceReplacement == "" {
+		dp.DeviceReplacement = "$1"
+	}
+	if dp.ModelReplacement == "" {
+		dp.ModelReplacement = "$1"
 	}
 }
 
@@ -209,6 +268,10 @@ func New(options ...Option) (*Parser, error) {
 	if parser.RegexDefinitions == nil {
 		regexesDefinitions := defaultRegexesDefinitions()
 		parser.RegexDefinitions = &regexesDefinitions
+	}
+
+	if parser.config.UseSort {
+		parser.RegexDefinitions = parser.RegexDefinitions.Clone()
 	}
 
 	parser.mustCompile()

--- a/uaparser/parser.go
+++ b/uaparser/parser.go
@@ -180,7 +180,7 @@ func New(options ...Option) (*Parser, error) {
 			UseSort:         cDefaultSortOption,
 			DebugMode:       cDefaultDebugMode,
 			CacheSize:       cDefaultCacheSize,
-			MissesThreshold: cMinMissesTreshold,
+			MissesThreshold: cDefaultMissesTreshold,
 			MatchIdxNotOk:   cDefaultMatchIdxNotOk,
 		},
 		mu: &sync.RWMutex{},

--- a/uaparser/parser.go
+++ b/uaparser/parser.go
@@ -444,13 +444,7 @@ func checkAndSort(parser *Parser) {
 		}
 		parser.DeviceMisses = 0
 
-		// create a copy to avoid modifying the original slice while in use.
-		deviceDefinitions := make([]*deviceParser, len(parser.RegexDefinitions.Device))
-		copy(deviceDefinitions, parser.RegexDefinitions.Device)
-
-		sort.Sort(DeviceSorter(deviceDefinitions))
-
-		parser.RegexDefinitions.Device = deviceDefinitions
+		sort.Sort(DeviceSorter(parser.RegexDefinitions.Device))
 	}
 	parser.mu.Unlock()
 }

--- a/uaparser/parser.go
+++ b/uaparser/parser.go
@@ -234,6 +234,10 @@ func New(regexFile string) (*Parser, error) {
 }
 
 func NewFromSaved() *Parser {
+	return NewFromSavedWithOptions(defaultParserConfig())
+}
+
+func NewFromSavedWithOptions(config *parserConfig) *Parser {
 	parser, err := newFromBytes(DefinitionYaml, defaultParserConfig())
 	if err != nil {
 		// if the YAML is malformed, it's a programmatic error inside what

--- a/uaparser/parser.go
+++ b/uaparser/parser.go
@@ -11,9 +11,9 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-var defaultRegexesDefinitions = sync.OnceValue(func() *RegexesDefinitions {
-	def := &RegexesDefinitions{}
-	if err := yaml.Unmarshal(DefinitionYaml, def); err != nil {
+var defaultRegexesDefinitions = sync.OnceValue(func() RegexesDefinitions {
+	var def RegexesDefinitions
+	if err := yaml.Unmarshal(DefinitionYaml, &def); err != nil {
 		panic(fmt.Errorf("error parsing regexes definitions: %w", err))
 	}
 
@@ -207,7 +207,8 @@ func New(options ...Option) (*Parser, error) {
 	}
 
 	if parser.RegexesDefinitions == nil {
-		parser.RegexesDefinitions = defaultRegexesDefinitions()
+		regexesDefinitions := defaultRegexesDefinitions()
+		parser.RegexesDefinitions = &regexesDefinitions
 	}
 
 	parser.mustCompile()

--- a/uaparser/parser.go
+++ b/uaparser/parser.go
@@ -12,7 +12,7 @@ import (
 )
 
 var defaultRegexesDefinitions = sync.OnceValue(func() *RegexesDefinitions {
-	var def *RegexesDefinitions
+	def := &RegexesDefinitions{}
 	if err := yaml.Unmarshal(DefinitionYaml, def); err != nil {
 		panic(fmt.Errorf("error parsing regexes definitions: %w", err))
 	}

--- a/uaparser/parser.go
+++ b/uaparser/parser.go
@@ -434,13 +434,7 @@ func checkAndSort(parser *Parser) {
 		}
 		parser.OsMisses = 0
 
-		// create a copy to avoid modifying the original slice while in use.
-		osDefinitions := make([]*osParser, len(parser.RegexDefinitions.OS))
-		copy(osDefinitions, parser.RegexDefinitions.OS)
-
-		sort.Sort(OsSorter(osDefinitions))
-
-		parser.RegexDefinitions.OS = osDefinitions
+		sort.Sort(OsSorter(parser.RegexDefinitions.OS))
 	}
 	parser.mu.Unlock()
 	parser.mu.Lock()

--- a/uaparser/parser.go
+++ b/uaparser/parser.go
@@ -238,7 +238,7 @@ func NewFromSaved() *Parser {
 }
 
 func NewFromSavedWithOptions(config *parserConfig) *Parser {
-	parser, err := newFromBytes(DefinitionYaml, defaultParserConfig())
+	parser, err := newFromBytes(DefinitionYaml, config)
 	if err != nil {
 		// if the YAML is malformed, it's a programmatic error inside what
 		// we've statically-compiled in our binary. Panic!

--- a/uaparser/parser.go
+++ b/uaparser/parser.go
@@ -216,15 +216,15 @@ func New(options ...Option) (*Parser, error) {
 }
 
 func (parser *Parser) mustCompile() { // until we can use yaml.UnmarshalYAML with embedded pointer struct
-	for _, p := range parser.UA {
+	for _, p := range parser.RegexesDefinitions.UA {
 		p.Reg = compileRegex(p.Flags, p.Expr)
 		p.setDefaults()
 	}
-	for _, p := range parser.OS {
+	for _, p := range parser.RegexesDefinitions.OS {
 		p.Reg = compileRegex(p.Flags, p.Expr)
 		p.setDefaults()
 	}
-	for _, p := range parser.Device {
+	for _, p := range parser.RegexesDefinitions.Device {
 		p.Reg = compileRegex(p.Flags, p.Expr)
 		p.setDefaults()
 	}
@@ -275,7 +275,7 @@ func (parser *Parser) ParseUserAgent(line string) *UserAgent {
 	ua := new(UserAgent)
 	foundIdx := -1
 	found := false
-	for i, uaPattern := range parser.UA {
+	for i, uaPattern := range parser.RegexesDefinitions.UA {
 		uaPattern.Match(line, ua)
 		if len(ua.Family) > 0 {
 			found = true
@@ -303,7 +303,7 @@ func (parser *Parser) ParseOs(line string) *Os {
 	os := new(Os)
 	foundIdx := -1
 	found := false
-	for i, osPattern := range parser.OS {
+	for i, osPattern := range parser.RegexesDefinitions.OS {
 		osPattern.Match(line, os)
 		if len(os.Family) > 0 {
 			found = true
@@ -332,7 +332,7 @@ func (parser *Parser) ParseDevice(line string) *Device {
 	dvc := new(Device)
 	foundIdx := -1
 	found := false
-	for i, dvcPattern := range parser.Device {
+	for i, dvcPattern := range parser.RegexesDefinitions.Device {
 		dvcPattern.Match(line, dvc)
 		if len(dvc.Family) > 0 {
 			found = true
@@ -359,7 +359,7 @@ func checkAndSort(parser *Parser) {
 			fmt.Printf("%s\tSorting UserAgents slice\n", time.Now())
 		}
 		parser.UserAgentMisses = 0
-		sort.Sort(UserAgentSorter(parser.UA))
+		sort.Sort(UserAgentSorter(parser.RegexesDefinitions.UA))
 	}
 	parser.mu.Unlock()
 	parser.mu.Lock()
@@ -368,7 +368,7 @@ func checkAndSort(parser *Parser) {
 			fmt.Printf("%s\tSorting OS slice\n", time.Now())
 		}
 		parser.OsMisses = 0
-		sort.Sort(OsSorter(parser.OS))
+		sort.Sort(OsSorter(parser.RegexesDefinitions.OS))
 	}
 	parser.mu.Unlock()
 	parser.mu.Lock()
@@ -377,7 +377,7 @@ func checkAndSort(parser *Parser) {
 			fmt.Printf("%s\tSorting Device slice\n", time.Now())
 		}
 		parser.DeviceMisses = 0
-		sort.Sort(DeviceSorter(parser.Device))
+		sort.Sort(DeviceSorter(parser.RegexesDefinitions.Device))
 	}
 	parser.mu.Unlock()
 }

--- a/uaparser/parser.go
+++ b/uaparser/parser.go
@@ -424,13 +424,7 @@ func checkAndSort(parser *Parser) {
 		}
 		parser.UserAgentMisses = 0
 
-		// create a copy to avoid modifying the original slice while in use.
-		uaDefinitions := make([]*uaParser, len(parser.RegexDefinitions.UA))
-		copy(uaDefinitions, parser.RegexDefinitions.UA)
-
-		sort.Sort(UserAgentSorter(uaDefinitions))
-
-		parser.RegexDefinitions.UA = uaDefinitions
+		sort.Sort(UserAgentSorter(parser.RegexDefinitions.UA))
 	}
 	parser.mu.Unlock()
 	parser.mu.Lock()

--- a/uaparser/parser.go
+++ b/uaparser/parser.go
@@ -360,7 +360,14 @@ func checkAndSort(parser *Parser) {
 			fmt.Printf("%s\tSorting UserAgents slice\n", time.Now())
 		}
 		parser.UserAgentMisses = 0
-		sort.Sort(UserAgentSorter(parser.RegexDefinitions.UA))
+
+		// create a copy to avoid modifying the original slice while in use.
+		uaDefinitions := make([]*uaParser, len(parser.RegexDefinitions.UA))
+		copy(uaDefinitions, parser.RegexDefinitions.UA)
+
+		sort.Sort(UserAgentSorter(uaDefinitions))
+
+		parser.RegexDefinitions.UA = uaDefinitions
 	}
 	parser.mu.Unlock()
 	parser.mu.Lock()
@@ -369,7 +376,14 @@ func checkAndSort(parser *Parser) {
 			fmt.Printf("%s\tSorting OS slice\n", time.Now())
 		}
 		parser.OsMisses = 0
-		sort.Sort(OsSorter(parser.RegexDefinitions.OS))
+
+		// create a copy to avoid modifying the original slice while in use.
+		osDefinitions := make([]*osParser, len(parser.RegexDefinitions.OS))
+		copy(osDefinitions, parser.RegexDefinitions.OS)
+
+		sort.Sort(OsSorter(osDefinitions))
+
+		parser.RegexDefinitions.OS = osDefinitions
 	}
 	parser.mu.Unlock()
 	parser.mu.Lock()
@@ -378,7 +392,14 @@ func checkAndSort(parser *Parser) {
 			fmt.Printf("%s\tSorting Device slice\n", time.Now())
 		}
 		parser.DeviceMisses = 0
-		sort.Sort(DeviceSorter(parser.RegexDefinitions.Device))
+
+		// create a copy to avoid modifying the original slice while in use.
+		deviceDefinitions := make([]*deviceParser, len(parser.RegexDefinitions.Device))
+		copy(deviceDefinitions, parser.RegexDefinitions.Device)
+
+		sort.Sort(DeviceSorter(deviceDefinitions))
+
+		parser.RegexDefinitions.Device = deviceDefinitions
 	}
 	parser.mu.Unlock()
 }

--- a/uaparser/parsing_test.go
+++ b/uaparser/parsing_test.go
@@ -12,7 +12,13 @@ var testParser *Parser
 
 func init() {
 	var err error
-	testParser, err = New("../uap-core/regexes.yaml")
+
+	uaRegexes, err := os.ReadFile("../uap-core/regexes.yaml")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	testParser, err = New(uaRegexes)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -38,8 +44,13 @@ func TestOSParsing(t *testing.T) {
 	}
 }
 
-func TestReadsInteralYAML(t *testing.T) {
-	_ = NewFromSaved() // should not panic
+func TestReadsInternalYAML(t *testing.T) {
+	t.Parallel()
+
+	_, err := New(DefinitionYaml)
+	if err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestUAParsing(t *testing.T) {

--- a/uaparser/parsing_test.go
+++ b/uaparser/parsing_test.go
@@ -18,7 +18,13 @@ func init() {
 		log.Fatal(err)
 	}
 
-	testParser, err = New(uaRegexes)
+	var def *RegexesDefinitions
+
+	if err := yaml.Unmarshal(uaRegexes, def); err != nil {
+		log.Fatal(err)
+	}
+
+	testParser, err = New(WithRegexesDefinitions(def))
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -47,7 +53,7 @@ func TestOSParsing(t *testing.T) {
 func TestReadsInternalYAML(t *testing.T) {
 	t.Parallel()
 
-	_, err := New(DefinitionYaml)
+	_, err := New()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/uaparser/parsing_test.go
+++ b/uaparser/parsing_test.go
@@ -18,9 +18,9 @@ func init() {
 		log.Fatal(err)
 	}
 
-	def := &RegexesDefinitions{}
+	var def RegexesDefinitions
 
-	if err := yaml.Unmarshal(uaRegexes, def); err != nil {
+	if err := yaml.Unmarshal(uaRegexes, &def); err != nil {
 		log.Fatal(err)
 	}
 

--- a/uaparser/parsing_test.go
+++ b/uaparser/parsing_test.go
@@ -18,7 +18,7 @@ func init() {
 		log.Fatal(err)
 	}
 
-	var def *RegexesDefinitions
+	def := &RegexesDefinitions{}
 
 	if err := yaml.Unmarshal(uaRegexes, def); err != nil {
 		log.Fatal(err)

--- a/uaparser/parsing_test.go
+++ b/uaparser/parsing_test.go
@@ -18,13 +18,13 @@ func init() {
 		log.Fatal(err)
 	}
 
-	var def RegexesDefinitions
+	var def RegexDefinitions
 
 	if err := yaml.Unmarshal(uaRegexes, &def); err != nil {
 		log.Fatal(err)
 	}
 
-	testParser, err = New(WithRegexesDefinitions(def))
+	testParser, err = New(WithRegexDefinitions(def))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/uaparser/user_agent.go
+++ b/uaparser/user_agent.go
@@ -7,13 +7,13 @@ type UserAgent struct {
 	Patch  string
 }
 
-func (parser *uaParser) Match(line string, ua *UserAgent) {
-	matches := parser.Reg.FindStringSubmatchIndex(line)
+func (uap *uaParser) Match(line string, ua *UserAgent) {
+	matches := uap.Reg.FindStringSubmatchIndex(line)
 	if len(matches) > 0 {
-		ua.Family = string(parser.Reg.ExpandString(nil, parser.FamilyReplacement, line, matches))
-		ua.Major = string(parser.Reg.ExpandString(nil, parser.V1Replacement, line, matches))
-		ua.Minor = string(parser.Reg.ExpandString(nil, parser.V2Replacement, line, matches))
-		ua.Patch = string(parser.Reg.ExpandString(nil, parser.V3Replacement, line, matches))
+		ua.Family = string(uap.Reg.ExpandString(nil, uap.FamilyReplacement, line, matches))
+		ua.Major = string(uap.Reg.ExpandString(nil, uap.V1Replacement, line, matches))
+		ua.Minor = string(uap.Reg.ExpandString(nil, uap.V2Replacement, line, matches))
+		ua.Patch = string(uap.Reg.ExpandString(nil, uap.V3Replacement, line, matches))
 	}
 }
 


### PR DESCRIPTION
Today, we have separate functions for creating the Parser - `NewFromSaved` for using the built-in yaml definitions, `NewFromBytes` for providing your own regexes as bytes of a yaml file, and `NewWithOptions` for providing a path to a yaml file with various options from the library selected - e.g. configuring the LRU cache size, turning on the (unsafe) sorting mode, and options related to that.

This PR implements a `New` function that using the [function options pattern](https://golang.cafe/blog/golang-functional-options-pattern.html).  So instead of using any of the old interfaces, you can now `New(WithRegexDefinitions(...))` to provide your own regexes, `New(WithCacheSize(...))` to customize the cache size, or any combination of our new `With*` functions - the full list added here is: `WithMode`, `WithDebug`, `WithSort`, `WithCacheSize`, `WithMissesThreshold`, `WithMatchIdxNotOk`, and `WithRegexDefinitions`