### PR TITLE
docs: fix README regex definitions example

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,14 +57,14 @@ func main() {
 	  log.Fatal(err)
   }
 
-  var def *uaparser.RegexesDefinitions
+  var def *uaparser.RegexDefinitions
 
   if err := yaml.Unmarshal(regexes, def); err != nil {
     fmt.Printf("error parsing regexes definitions. Error: %s\n", err.Error())
     return
   }
   
-  parser, err := uaparser.New(uaparser.WithRegexesDefinitions(def))
+  parser, err := uaparser.New(uaparser.WithRegexDefinitions(def))
   if err != nil {
     log.Fatal(err)
   }


### PR DESCRIPTION
<!-- hermes-auto-maintainer -->

## Summary
- Correct the README example identifiers from `RegexesDefinitions`/`WithRegexesDefinitions` to `RegexDefinitions`/`WithRegexDefinitions`.

Fixes #99

## Test plan
- static validation: `WithRegexesDefinitions` appeared 1 time(s) in `README.md` before replacement.
- static validation: `WithRegexesDefinitions` absent and `WithRegexDefinitions` present in `README.md` after patch.
- static validation: `RegexesDefinitions` appeared 1 time(s) in `README.md` before replacement.
- static validation: `RegexesDefinitions` absent and `RegexDefinitions` present in `README.md` after patch.
- Not run: runtime test suite, because this is a documentation-only fix.
