### PR TITLE
fix(uaparser): clone the shared default RegexDefinitions in New

### DIFF
--- a/uaparser/parser.go
+++ b/uaparser/parser.go
@@ -266,11 +266,12 @@ func New(options ...Option) (*Parser, error) {
 	}
 
 	if parser.RegexDefinitions == nil {
+		// Clone the cached default so the per-parser mustCompile() writes
+		// to its own pointer set instead of the shared sync.OnceValue
+		// slice elements.
 		regexesDefinitions := defaultRegexesDefinitions()
-		parser.RegexDefinitions = &regexesDefinitions
-	}
-
-	if parser.config.UseSort {
+		parser.RegexDefinitions = regexesDefinitions.Clone()
+	} else if parser.config.UseSort {
 		parser.RegexDefinitions = parser.RegexDefinitions.Clone()
 	}
 

--- a/uaparser/race_test.go
+++ b/uaparser/race_test.go
@@ -1,0 +1,25 @@
+package uaparser
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestNewConcurrent_NoRaceOnDefaultRegexDefinitions reproduces the data race
+// reported in issue #100. Without the fix, multiple goroutines calling New()
+// with the default cached RegexDefinitions racing on the shared []*uaParser
+// pointers triggers a race detector failure under -race.
+func TestNewConcurrent_NoRaceOnDefaultRegexDefinitions(t *testing.T) {
+	const n = 16
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			if _, err := New(); err != nil {
+				t.Errorf("New: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
The cached default returned by `defaultRegexesDefinitions` is a `sync.OnceValue` of a `RegexDefinitions` value, but its UA/OS/Device fields are slices of pointers shared across every `New` call, so `mustCompile` writes `p.Reg` on the same elements from two goroutines initializing in parallel. Cloning the cached default in `New` gives each parser its own pointer set, and a new `-race` test exercises 16 concurrent `New()` calls.

Closes #100